### PR TITLE
feat: Sprint 2 완료 — LangGraph 구조화 + 성과지표 + Streamlit 대시보드

### DIFF
--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -1,18 +1,594 @@
 """
-Streamlit 6탭 대시보드 (구현 예정).
+Streamlit 대시보드.
 
+streamlit-echarts 기반 인터랙티브 차트 + st.navigation 사이드바 네비게이션.
 FastAPI HTTP 통신만 사용하며, 모델을 직접 로드하지 않습니다.
-
-탭 구성 (Sprint 2~3 구현 예정):
-  Tab 1: 포트폴리오 현황
-  Tab 2: 투자 분석 (RAG 리포트)
-  Tab 3: 리스크 모니터링
-  Tab 4: 백테스트 결과
-  Tab 5: RL 학습 현황
-  Tab 6: 시장 국면 (ECOS 지표)
+API 미완성 상태에서는 mock 데이터로 UI를 렌더링합니다.
 """
-import streamlit as st
+from __future__ import annotations
 
-st.set_page_config(page_title="AI Robo Advisor", layout="wide")
-st.title("AI Robo Advisor Dashboard")
-st.info("대시보드 구현 중입니다. (Sprint 2~3 예정)")
+import os
+from datetime import date, timedelta
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import requests
+import streamlit as st
+from streamlit_echarts import JsCode, st_echarts
+
+# ─────────────────────────────────────────────
+# 설정
+# ─────────────────────────────────────────────
+
+API_BASE_URL: str = os.getenv("API_BASE_URL", "http://localhost:8000")
+REQUEST_TIMEOUT: int = 10
+
+_PALETTE = ["#5470c6", "#91cc75", "#fac858", "#ee6666", "#73c0de",
+            "#3ba272", "#fc8452", "#9a60b4", "#ea7ccc", "#48b8d0"]
+
+_PERIOD_MONTHS = {"1개월": 21, "3개월": 63, "6개월": 126, "12개월": 252, "전체": None}
+
+
+# ─────────────────────────────────────────────
+# API helpers
+# ─────────────────────────────────────────────
+
+def _get(endpoint: str, params: dict | None = None) -> dict[str, Any] | None:
+    try:
+        resp = requests.get(f"{API_BASE_URL}{endpoint}", params=params, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as e:
+        st.warning(f"API 연결 실패 ({endpoint}): {e} — mock 데이터로 표시합니다.")
+        return None
+
+
+def _post(endpoint: str, payload: dict) -> dict[str, Any] | None:
+    try:
+        resp = requests.post(f"{API_BASE_URL}{endpoint}", json=payload, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as e:
+        st.warning(f"API 연결 실패 ({endpoint}): {e} — mock 데이터로 표시합니다.")
+        return None
+
+
+# ─────────────────────────────────────────────
+# ECharts 공통 빌더
+# ─────────────────────────────────────────────
+
+def _echarts_line(
+    x: list, series: list[dict], title: str = "",
+    height: str = "380px", y_formatter: str = "",
+    zoom: bool = True, key: str = "chart",
+) -> None:
+    opts: dict = {
+        "title": {"text": title, "left": "center", "top": 4, "textStyle": {"fontSize": 14}},
+        "tooltip": {"trigger": "axis"},
+        "legend": {"bottom": 0, "type": "scroll"},
+        "grid": {"bottom": "18%" if zoom else "12%", "top": "12%", "containLabel": True},
+        "xAxis": {"type": "category", "data": x, "boundaryGap": False},
+        "yAxis": {"type": "value",
+                  "axisLabel": {"formatter": y_formatter} if y_formatter else {}},
+        "series": series,
+    }
+    if zoom:
+        opts["dataZoom"] = [
+            {"type": "inside", "start": 0, "end": 100},
+            {"type": "slider", "start": 0, "end": 100, "height": 18, "bottom": 24},
+        ]
+    st_echarts(options=opts, height=height, theme="streamlit", key=key)
+
+
+def _echarts_bar_h(
+    names: list, values: list, title: str = "",
+    colors: list | None = None, height: str = "360px", key: str = "bar_h",
+) -> None:
+    bar_data = (
+        [{"value": v, "itemStyle": {"color": c}} for v, c in zip(values, colors)]
+        if colors else values
+    )
+    opts = {
+        "title": {"text": title, "left": "center", "top": 4, "textStyle": {"fontSize": 14}},
+        "tooltip": {"trigger": "axis", "axisPointer": {"type": "shadow"}},
+        "grid": {"left": "3%", "right": "8%", "bottom": "8%", "containLabel": True},
+        "xAxis": {"type": "value"},
+        "yAxis": {"type": "category", "data": names},
+        "series": [{"type": "bar", "data": bar_data}],
+    }
+    st_echarts(options=opts, height=height, theme="streamlit", key=key)
+
+
+def _echarts_donut(
+    labels: list, values: list, title: str = "",
+    height: str = "380px", key: str = "donut",
+) -> None:
+    data = [{"name": l, "value": round(v, 4)} for l, v in zip(labels, values)]
+    opts = {
+        "title": {"text": title, "left": "center", "top": 4, "textStyle": {"fontSize": 14}},
+        "tooltip": {"trigger": "item", "formatter": "{b}: {d}%"},
+        "legend": {"bottom": 0, "type": "scroll"},
+        "series": [{
+            "type": "pie", "radius": ["38%", "65%"], "avoidLabelOverlap": True,
+            "itemStyle": {"borderRadius": 8, "borderColor": "#fff", "borderWidth": 2},
+            "label": {"show": True, "formatter": "{b}\n{d}%", "fontSize": 11},
+            "emphasis": {"label": {"show": True, "fontSize": 13, "fontWeight": "bold"}},
+            "data": data,
+        }],
+    }
+    st_echarts(options=opts, height=height, theme="streamlit", key=key)
+
+
+def _echarts_gauge(
+    value: float, title: str, max_val: float = 0.1,
+    height: str = "260px", key: str = "gauge",
+) -> None:
+    pct = round(value * 100, 2)
+    color = "#ee6666" if pct > 3 else "#fac858" if pct > 1.5 else "#91cc75"
+    opts = {
+        "series": [{
+            "type": "gauge", "min": 0, "max": round(max_val * 100, 1),
+            "progress": {"show": True, "width": 14},
+            "axisLine": {"lineStyle": {"width": 14}},
+            "axisTick": {"show": False},
+            "splitLine": {"length": 10, "lineStyle": {"width": 2, "color": "#999"}},
+            "axisLabel": {"distance": 20, "fontSize": 11,
+                          "formatter": JsCode("function(v){return v+'%'}")},
+            "detail": {"valueAnimation": True, "fontSize": 28, "offsetCenter": [0, "60%"],
+                       "formatter": JsCode("function(v){return v.toFixed(2)+'%'}")},
+            "title": {"offsetCenter": [0, "88%"], "fontSize": 12},
+            "data": [{"value": pct, "name": title}],
+            "itemStyle": {"color": color},
+        }],
+    }
+    st_echarts(options=opts, height=height, theme="streamlit", key=key)
+
+
+# ─────────────────────────────────────────────
+# Mock 데이터
+# ─────────────────────────────────────────────
+
+_ASSETS = ["삼성전자", "SK하이닉스", "NAVER", "카카오", "현대차",
+           "LG에너솔", "POSCO홀딩스", "삼성SDI", "KB금융", "셀트리온"]
+_rng = np.random.default_rng(42)
+
+
+def _mock_optimize(risk_aversion: float = 1.0) -> dict:
+    w = _rng.dirichlet(np.ones(len(_ASSETS)) * (1 / risk_aversion))
+    dates = pd.date_range("2024-01-01", periods=252, freq="B").strftime("%Y-%m-%d").tolist()
+    return {
+        "weights": dict(zip(_ASSETS, w.tolist())),
+        "returns": {
+            "date": dates,
+            "portfolio": np.cumprod(1 + _rng.normal(0.0005, 0.012, 252)).tolist(),
+            "benchmark": np.cumprod(1 + _rng.normal(0.0003, 0.010, 252)).tolist(),
+        },
+    }
+
+
+def _mock_backtest() -> dict:
+    dates = pd.date_range("2024-01-01", periods=252, freq="B").strftime("%Y-%m-%d").tolist()
+    wf = _rng.normal(0.001, 0.015, 252)
+    bm = _rng.normal(0.0003, 0.010, 252)
+    prices = np.cumprod(1 + wf)
+    drawdown = ((prices - np.maximum.accumulate(prices)) / np.maximum.accumulate(prices)).tolist()
+    metrics = {
+        "cumulative_return": 0.248, "cagr": 0.231, "annualized_volatility": 0.182,
+        "var_95": 0.021, "cvar_95": 0.031, "mdd": 0.127,
+        "sharpe_ratio": 1.27, "sortino_ratio": 1.85, "calmar_ratio": 1.82,
+        "alpha": 0.043, "beta": 0.92, "information_ratio": 0.68,
+    }
+    return {
+        "dates": dates,
+        "rewards": _rng.normal(0.002, 0.05, 200).cumsum().tolist(),
+        "wf_cum": np.cumprod(1 + wf).tolist(),
+        "bm_cum": np.cumprod(1 + bm).tolist(),
+        "wf_spark": np.cumprod(1 + wf[:50]).tolist(),
+        "sharpe_spark": (np.cumsum(_rng.normal(0, 0.3, 50)) + 1.27).tolist(),
+        "drawdown": drawdown,
+        "metrics": metrics,
+        "anova": {
+            "f_statistic": 12.34, "p_value": 0.0003, "eta_squared": 0.187,
+            "posthoc": [
+                {"group_a": "PPO", "group_b": "MVO", "p_value": 0.002, "significant": True},
+                {"group_a": "PPO", "group_b": "동일비중", "p_value": 0.041, "significant": True},
+                {"group_a": "MVO", "group_b": "동일비중", "p_value": 0.312, "significant": False},
+            ],
+        },
+        "var_95": metrics["var_95"], "cvar_95": metrics["cvar_95"], "mdd": metrics["mdd"],
+        "safeguard": {"active": False, "triggered_at": None, "current_drawdown": 0.043},
+    }
+
+
+def _mock_explain(target_date: str) -> dict:
+    feat = ["RSI_14", "MACD", "MACD_signal", "BB_width", "log_return_1d",
+            "log_return_5d", "volume_ratio", "gold_corr", "krw_usd", "기준금리"]
+    vals = _rng.normal(0, 0.05, len(feat)).tolist()
+    base = 0.002
+    return {"target_date": target_date, "feature_names": feat,
+            "shap_values": vals, "base_value": base, "prediction": base + sum(vals)}
+
+
+def _mock_research(question: str) -> dict:
+    return {
+        "report": (
+            f"**[Mock 리포트]** '{question}'에 대한 분석입니다.\n\n"
+            "현재 시장은 글로벌 금리 인상 기조와 반도체 업황 회복 사이의 긴장 속에 있습니다. "
+            "국내 대형주는 외국인 수급 개선으로 단기 반등 가능성이 있으나, "
+            "미 연준의 금리 경로 불확실성은 여전히 상방 리스크로 작용합니다.\n\n"
+            "---\n**[면책 조항]** 본 분석은 교육 목적으로만 제공됩니다."
+        ),
+        "sources": ["https://news.example.com/article/1", "https://news.example.com/article/2"],
+        "reasoning_trace": (
+            "[THINK][planner] 질의 분석 시작\n"
+            "[THINK][researcher] 초기 검색: Chroma hit=5건\n"
+            "[THINK][grade_documents] 판정: 충분 — analyst 진행\n"
+            "[THINK][analyst] 최종 리포트 생성 착수"
+        ),
+        "risk_tags": ["급등락"],
+    }
+
+
+# ─────────────────────────────────────────────
+# 페이지 함수
+# ─────────────────────────────────────────────
+
+def portfolio_page() -> None:
+    # 페이지 전용 사이드바 컨트롤
+    with st.sidebar:
+        st.divider()
+        st.subheader(":material/tune: 포트폴리오 설정")
+        risk_aversion = st.slider(
+            "위험 회피 계수",
+            min_value=0.5, max_value=5.0, value=1.0, step=0.5,
+            help="값이 클수록 분산 투자 비중 증가",
+        )
+
+    st.title("포트폴리오 현황")
+
+    if st.button("최적화 실행", key="btn_optimize"):
+        with st.spinner("POST /optimize 호출 중…"):
+            data = _post("/optimize", {"risk_aversion": risk_aversion}) or _mock_optimize(risk_aversion)
+    else:
+        data = _mock_optimize(risk_aversion)
+
+    # 기간 슬라이싱
+    n = _PERIOD_MONTHS[period]
+    ret = data["returns"]
+    x = ret["date"][-n:] if n else ret["date"]
+    port_vals = ret["portfolio"][-n:] if n else ret["portfolio"]
+    bm_vals = ret["benchmark"][-n:] if n else ret["benchmark"]
+
+    ret_arr = np.array(port_vals)
+    bm_arr = np.array(bm_vals)
+    cum_ret = float(ret_arr[-1] - 1)
+    excess = float(ret_arr[-1] - bm_arr[-1])
+    top_asset = max(data["weights"], key=data["weights"].get)
+
+    k1, k2, k3, k4 = st.columns(4)
+    k1.metric("누적 수익률", f"{cum_ret:.1%}", border=True)
+    k2.metric("초과 수익", f"{excess:.1%}", delta=f"{excess:.2%} vs KOSPI", border=True)
+    k3.metric("최대 비중 자산", top_asset, f"{data['weights'][top_asset]:.1%}", border=True)
+    k4.metric("편입 종목 수", f"{len(data['weights'])}개", border=True)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        with st.container(border=True):
+            _echarts_donut(
+                labels=list(data["weights"].keys()),
+                values=list(data["weights"].values()),
+                title="자산 비중", key="p_donut",
+            )
+    with col2:
+        with st.container(border=True):
+            _echarts_line(
+                x=x,
+                series=[
+                    {"name": "포트폴리오", "type": "line", "smooth": True,
+                     "areaStyle": {"opacity": 0.15}, "data": port_vals,
+                     "itemStyle": {"color": _PALETTE[0]}},
+                    {"name": "벤치마크(KOSPI)", "type": "line", "smooth": True,
+                     "data": bm_vals, "itemStyle": {"color": _PALETTE[3]}},
+                ],
+                title=f"누적 수익률 ({period})", key="p_line",
+            )
+
+    with st.expander("비중 상세 테이블"):
+        st.dataframe(
+            pd.DataFrame({"자산": list(data["weights"].keys()),
+                          "비중": [f"{v:.2%}" for v in data["weights"].values()]}),
+            hide_index=True, use_container_width=True,
+        )
+
+
+def rl_page() -> None:
+    st.title("강화학습 성과")
+    with st.spinner("GET /backtest 호출 중…"):
+        bt = _get("/backtest") or _mock_backtest()
+
+    # 기간 슬라이싱
+    n = _PERIOD_MONTHS[period]
+    dates = bt["dates"][-n:] if n else bt["dates"]
+    wf_cum = bt["wf_cum"][-n:] if n else bt["wf_cum"]
+    bm_cum = bt["bm_cum"][-n:] if n else bt["bm_cum"]
+
+    m = bt["metrics"]
+    c1, c2, c3 = st.columns(3)
+    c1.metric("누적 수익률", f"{m['cumulative_return']:.1%}", border=True,
+              chart_data=bt.get("wf_spark"), chart_type="area")
+    c2.metric("샤프 비율", f"{m['sharpe_ratio']:.2f}", border=True,
+              chart_data=bt.get("sharpe_spark"), chart_type="line")
+    c3.metric("MDD", f"{m['mdd']:.1%}", border=True)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        with st.container(border=True):
+            _echarts_line(
+                x=list(range(1, len(bt["rewards"]) + 1)),
+                series=[{"name": "누적 보상", "type": "line", "smooth": True,
+                         "areaStyle": {"opacity": 0.12}, "data": bt["rewards"],
+                         "itemStyle": {"color": _PALETTE[1]}}],
+                title="학습 곡선 (에피소드 누적 보상)", key="rl_reward",
+            )
+    with col2:
+        with st.container(border=True):
+            # 비교 전략 필터 적용
+            series_list = []
+            if "PPO" in strategies:
+                series_list.append({
+                    "name": "PPO", "type": "line", "smooth": True,
+                    "areaStyle": {"opacity": 0.12}, "data": wf_cum,
+                    "itemStyle": {"color": _PALETTE[0]},
+                })
+            if "MVO" in strategies:
+                series_list.append({
+                    "name": "MVO (mock)", "type": "line", "smooth": True,
+                    "data": (np.array(wf_cum) * 0.92).tolist(),
+                    "itemStyle": {"color": _PALETTE[2]},
+                })
+            if "동일비중" in strategies:
+                series_list.append({
+                    "name": "동일비중 (mock)", "type": "line", "smooth": True,
+                    "lineStyle": {"type": "dashed"},
+                    "data": bm_cum,
+                    "itemStyle": {"color": _PALETTE[3]},
+                })
+            if not series_list:
+                st.info("비교 전략을 하나 이상 선택하세요.")
+            else:
+                _echarts_line(
+                    x=dates, series=series_list,
+                    title=f"Walk-Forward 백테스트 ({period})", key="rl_wf",
+                )
+
+    with st.container(border=True):
+        st.markdown("**성과 지표 전체**")
+        st.dataframe(
+            pd.DataFrame([{"지표": k, "값": f"{v:.4f}"} for k, v in m.items()]),
+            hide_index=True, use_container_width=True,
+        )
+
+
+def shap_page() -> None:
+    # 페이지 전용 사이드바 컨트롤
+    with st.sidebar:
+        st.divider()
+        st.subheader(":material/calendar_month: SHAP 설정")
+        target_date = st.date_input(
+            "분석 날짜",
+            value=date.today() - timedelta(days=1),
+            min_value=date(2020, 1, 1),
+            max_value=date.today(),
+        )
+
+    st.title("SHAP 해석")
+
+    if st.button("SHAP 분석 실행", key="btn_explain"):
+        with st.spinner("POST /explain 호출 중…"):
+            sd = _post("/explain", {"date": str(target_date)}) or _mock_explain(str(target_date))
+    else:
+        sd = _mock_explain(str(target_date))
+
+    feat, vals, base, pred = sd["feature_names"], sd["shap_values"], sd["base_value"], sd["prediction"]
+    st.markdown(f"분석 날짜: **{target_date}** | 기준값: **`{base:.4f}`** → 예측값: **`{pred:.4f}`**")
+
+    shap_df = pd.DataFrame({"피처": feat, "SHAP값": vals}).sort_values("SHAP값")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        with st.container(border=True):
+            summary = shap_df.copy()
+            summary["절대값"] = summary["SHAP값"].abs()
+            summary = summary.sort_values("절대값")
+            _echarts_bar_h(
+                names=summary["피처"].tolist(),
+                values=summary["절대값"].round(4).tolist(),
+                title="Summary Plot (|SHAP| 절대값)", key="shap_summary",
+            )
+    with col2:
+        with st.container(border=True):
+            colors = ["#ee6666" if v > 0 else "#5470c6" for v in shap_df["SHAP값"]]
+            _echarts_bar_h(
+                names=shap_df["피처"].tolist(),
+                values=shap_df["SHAP값"].round(4).tolist(),
+                colors=colors,
+                title="Force Plot (빨강=양, 파랑=음)", key="shap_force",
+            )
+
+
+def research_page() -> None:
+    st.title("에이전트 리서치 (RAG)")
+
+    question = st.text_area(
+        "투자 질문 입력",
+        placeholder="예: 삼성전자 HBM 반도체 실적 전망은?",
+        height=80,
+    )
+
+    if st.button("리서치 실행", key="btn_research"):
+        if not question.strip():
+            st.error("질문을 입력하세요.")
+        else:
+            with st.spinner("POST /research 호출 중 (최대 30초)…"):
+                res = _post("/research", {"question": question}) or _mock_research(question)
+
+            col1, col2 = st.columns([2, 1])
+            with col1:
+                with st.container(border=True):
+                    st.markdown("**분석 리포트**")
+                    st.markdown(res["report"])
+            with col2:
+                with st.container(border=True):
+                    st.markdown("**출처 URL**")
+                    for url in res.get("sources", []):
+                        st.markdown(f"- [{url}]({url})")
+                with st.container(border=True):
+                    st.markdown("**리스크 태그**")
+                    tags = res.get("risk_tags", [])
+                    if tags:
+                        for t in tags:
+                            st.warning(f"⚠️ {t}")
+                    else:
+                        st.success("감지된 리스크 없음")
+
+            with st.expander("추론 트레이스 (reasoning_trace)"):
+                st.code(res.get("reasoning_trace", ""), language="text")
+    else:
+        st.info("위에서 질문을 입력하고 '리서치 실행' 버튼을 누르세요.")
+
+
+def anova_page() -> None:
+    st.title("ANOVA 검증 결과")
+    with st.spinner("GET /backtest 호출 중…"):
+        bt5 = _get("/backtest") or _mock_backtest()
+
+    anova = bt5.get("anova", _mock_backtest()["anova"])
+
+    # 비교 전략 필터 적용
+    posthoc_all = anova.get("posthoc", [])
+    posthoc = [
+        row for row in posthoc_all
+        if row["group_a"] in strategies or row["group_b"] in strategies
+    ] if strategies else posthoc_all
+
+    a1, a2, a3 = st.columns(3)
+    a1.metric("F 통계량", f"{anova['f_statistic']:.2f}", border=True)
+    a2.metric("p-value", f"{anova['p_value']:.4f}", border=True)
+    a3.metric("η² (효과 크기)", f"{anova['eta_squared']:.3f}", border=True)
+
+    if anova["p_value"] < 0.05:
+        st.success("✅ 전략 간 성과 차이가 통계적으로 유의합니다 (p < 0.05)")
+    else:
+        st.warning("⚠️ 통계적으로 유의한 차이 없음 (p ≥ 0.05)")
+
+    with st.container(border=True):
+        st.markdown("**사후 검정 결과 (Tukey HSD)**")
+        if posthoc:
+            ph = pd.DataFrame(posthoc)
+            ph["유의여부"] = ph["significant"].map({True: "✅", False: "—"})
+            ph["p_value"] = ph["p_value"].map("{:.4f}".format)
+            st.dataframe(
+                ph[["group_a", "group_b", "p_value", "유의여부"]].rename(
+                    columns={"group_a": "전략 A", "group_b": "전략 B", "p_value": "p-value"}
+                ),
+                hide_index=True, use_container_width=True,
+            )
+        else:
+            st.info("왼쪽 사이드바에서 비교 전략을 선택하세요.")
+
+
+def risk_page() -> None:
+    st.title("리스크 모니터링")
+    with st.spinner("GET /backtest 호출 중…"):
+        bt6 = _get("/backtest") or _mock_backtest()
+
+    # 기간 슬라이싱
+    n = _PERIOD_MONTHS[period]
+    dates = bt6["dates"][-n:] if n else bt6["dates"]
+    drawdown = bt6["drawdown"][-n:] if n else bt6["drawdown"]
+
+    sg = bt6.get("safeguard", {})
+    if sg.get("active"):
+        st.error(f"🔴 Safe-Guard 발동 중 — {sg['triggered_at']} 이후 매매 중단")
+    else:
+        st.success(f"🟢 Safe-Guard 정상 — 현재 낙폭 {sg.get('current_drawdown', 0):.1%}")
+
+    g1, g2, g3 = st.columns(3)
+    with g1:
+        with st.container(border=True):
+            _echarts_gauge(bt6["var_95"], "VaR 95%", max_val=0.08, key="r_var")
+    with g2:
+        with st.container(border=True):
+            _echarts_gauge(bt6["cvar_95"], "CVaR 95%", max_val=0.08, key="r_cvar")
+    with g3:
+        with st.container(border=True):
+            _echarts_gauge(bt6["mdd"], "MDD", max_val=0.4, key="r_mdd")
+
+    with st.container(border=True):
+        _echarts_line(
+            x=dates,
+            series=[{
+                "name": "낙폭", "type": "line", "smooth": True,
+                "areaStyle": {"opacity": 0.3, "color": "#ee6666"},
+                "lineStyle": {"color": "#ee6666"},
+                "itemStyle": {"color": "#ee6666"},
+                "data": drawdown,
+            }],
+            title=f"MDD 추이 ({period})",
+            y_formatter=JsCode("function(v){return (v*100).toFixed(1)+'%'}"),
+            key="r_drawdown",
+        )
+
+    with st.container(border=True):
+        st.markdown("**리스크 지표 요약**")
+        m6 = bt6["metrics"]
+        st.dataframe(
+            pd.DataFrame([
+                {"지표": "VaR 95%",       "값": f"{bt6['var_95']:.2%}"},
+                {"지표": "CVaR 95%",      "값": f"{bt6['cvar_95']:.2%}"},
+                {"지표": "MDD",           "값": f"{bt6['mdd']:.2%}"},
+                {"지표": "연환산 변동성", "값": f"{m6['annualized_volatility']:.2%}"},
+                {"지표": "베타",          "값": f"{m6['beta']:.2f}"},
+                {"지표": "샤프 비율",     "값": f"{m6['sharpe_ratio']:.2f}"},
+            ]),
+            hide_index=True, use_container_width=True,
+        )
+
+
+# ─────────────────────────────────────────────
+# 앱 진입점
+# ─────────────────────────────────────────────
+
+st.set_page_config(page_title="AI Robo Advisor", layout="wide", page_icon="📈")
+
+# 네비게이션 (템플릿과 동일한 st.navigation + st.Page 방식)
+pg = st.navigation([
+    st.Page(portfolio_page, title="포트폴리오 현황", icon=":material/pie_chart:",   default=True),
+    st.Page(rl_page,        title="강화학습 성과",   icon=":material/psychology:"),
+    st.Page(shap_page,      title="SHAP 해석",       icon=":material/auto_graph:"),
+    st.Page(research_page,  title="에이전트 리서치", icon=":material/article:"),
+    st.Page(anova_page,     title="ANOVA 검증",      icon=":material/science:"),
+    st.Page(risk_page,      title="리스크 모니터링", icon=":material/shield:"),
+])
+
+# 네비게이션 아래 전역 필터 (템플릿 Filters 패턴)
+with st.sidebar:
+    st.divider()
+    st.subheader(":material/filter_alt: Filters")
+    period: str = st.selectbox(
+        "분석 기간",
+        list(_PERIOD_MONTHS.keys()),
+        index=3,
+    )
+    strategies: list[str] = st.multiselect(
+        "비교 전략",
+        ["PPO", "MVO", "동일비중"],
+        default=["PPO"],
+        help="강화학습 성과·ANOVA 탭에서 비교할 전략",
+    )
+    st.divider()
+    st.caption(f"API: `{API_BASE_URL}`")
+    st.caption("FastAPI 미연결 시 mock 데이터로 렌더링됩니다.")
+
+pg.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ curl_cffi==0.11.1
 # RL
 gymnasium[classic-control]==1.2.3
 stable-baselines3==2.8.0
+
+# 대시보드 차트
+streamlit-echarts>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ gymnasium[classic-control]==1.2.3
 stable-baselines3==2.8.0
 
 # 대시보드 차트
-streamlit-echarts>=0.6.0
+streamlit-echarts~=0.6.0

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -99,6 +99,8 @@ def run_graph(query: str) -> AgentState:
         "retry_count": 0,
         "needs_research_retry": False,
         "response": "",
+        "sources": [],
+        "reasoning_trace": "",
     }
     return graph.invoke(initial_state)
 
@@ -132,6 +134,8 @@ if __name__ == "__main__":
         "retry_count": 0,
         "needs_research_retry": False,
         "response": "",
+        "sources": [],
+        "reasoning_trace": "",
     }
 
     think_accum: List[str] = []

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -17,7 +17,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from apps.api.config import settings
-from src.agent.risk_tags import extract_risk_tags
+from src.agent.risk_tags import extract_risk_tags, extract_rl_risk_tags
 from src.agent.vectorstore import collection_document_count, query_documents
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,8 @@ class AgentState(TypedDict):
     retry_count: int
     needs_research_retry: bool
     response: str
+    sources: List[str]
+    reasoning_trace: str
     search_query: NotRequired[str]
 
 
@@ -322,23 +324,36 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
     ``context``와 리스크 태그를 근거로 최종 투자 관점 의견을 작성합니다.
 
     Args:
-        state: ``query``, ``context``, ``risk_tags`` 권장.
+        state: ``query``, ``context``, ``documents``, ``risk_tags`` 권장.
 
     Returns:
-        ``response`` 및 로그 ``messages``.
+        ``response`` (report), ``sources``, ``reasoning_trace``, ``risk_tags`` (3종) 및 로그 ``messages``.
     """
     query = state["query"]
     context = state.get("context") or "관련 문서 없음"
-    risk_tags: List[str] = state.get("risk_tags") or []
+    documents: List[Dict[str, Any]] = state.get("documents") or []
+    general_risk_tags: List[str] = state.get("risk_tags") or []
+
+    # 문서 URL 추출
+    sources: List[str] = [
+        doc.get("metadata", {}).get("url", "")
+        for doc in documents
+        if doc.get("metadata", {}).get("url", "")
+    ]
+
+    # RL 관측공간 연동용 3종 태그
+    all_text = " ".join(d.get("content", "") for d in documents)
+    rl_risk_tags: List[str] = extract_rl_risk_tags(all_text) if all_text else []
 
     msg = _think_log("analyst", "최종 리포트 생성 착수")
-    risk_summary = ", ".join(risk_tags) if risk_tags else "없음"
+    risk_summary = ", ".join(general_risk_tags) if general_risk_tags else "없음"
 
     sys = SystemMessage(
         content=(
             "당신은 전문 금융 투자 애널리스트입니다. "
             "제공 컨텍스트가 빈약하면 그 한계를 명시하고, "
-            "있을 경우 시장 동향·기회·리스크를 한국어로 간결히 정리하세요."
+            "있을 경우 시장 동향·기회·리스크를 한국어로 간결히 정리하세요. "
+            "분석 내용에 근거 문서의 출처 URL이 있으면 반드시 인용하세요."
         )
     )
     hum = HumanMessage(
@@ -360,11 +375,20 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
     except openai.OpenAIError as e:
         logger.error("analyst: LLM 호출 실패 (%s).", e)
         response = f"[분석 오류] LLM 호출에 실패했습니다: {type(e).__name__}" + DISCLAIMER
+
     tail = _think_log(
         "analyst",
-        f"응답 길이={len(response)}자 (미리보기: {response[:80]}…)",
+        f"응답 길이={len(response)}자 (출처={len(sources)}개, RL태그={rl_risk_tags or '없음'})",
     )
+
+    # reasoning_trace: 현재까지 누적된 THINK 로그 + 애널리스트 로그
+    prev_messages: List[str] = list(state.get("messages") or [])
+    reasoning_trace = "\n".join(prev_messages + [msg, tail])
+
     return {
         "response": response,
+        "sources": sources,
+        "reasoning_trace": reasoning_trace,
+        "risk_tags": rl_risk_tags,
         "messages": [msg, tail],
     }

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -40,7 +40,8 @@ class AgentState(TypedDict):
         plan: Planner가 만든 조사 계획.
         context: Researcher가 만든 RAG 컨텍스트 문자열.
         documents: 검색 문서 ``{"content", "metadata"}`` 리스트.
-        risk_tags: ``risk_tags`` 모듈 추출 태그.
+        risk_tags: ``risk_tags`` 모듈 추출 태그 (RAG 일반 태그).
+        rl_risk_tags: RL 관측공간 연동용 3종 태그 (규제변경·실적쇼크·급등락).
         distances: Chroma 거리 목록(문서 순). 없으면 빈 리스트.
         retry_count: Self-Correction 재검색 횟수.
         needs_research_retry: ``True``면 다음 노드가 researcher.
@@ -54,6 +55,7 @@ class AgentState(TypedDict):
     context: str
     documents: List[Dict[str, Any]]
     risk_tags: List[str]
+    rl_risk_tags: List[str]
     distances: List[float]
     retry_count: int
     needs_research_retry: bool
@@ -327,7 +329,7 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
         state: ``query``, ``context``, ``documents``, ``risk_tags`` 권장.
 
     Returns:
-        ``response`` (report), ``sources``, ``reasoning_trace``, ``risk_tags`` (3종) 및 로그 ``messages``.
+        ``response`` (report), ``sources``, ``reasoning_trace``, ``rl_risk_tags`` (3종) 및 로그 ``messages``.
     """
     query = state["query"]
     context = state.get("context") or "관련 문서 없음"
@@ -389,6 +391,6 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
         "response": response,
         "sources": sources,
         "reasoning_trace": reasoning_trace,
-        "risk_tags": rl_risk_tags,
+        "rl_risk_tags": rl_risk_tags,
         "messages": [msg, tail],
     }

--- a/src/agent/risk_tags.py
+++ b/src/agent/risk_tags.py
@@ -1,8 +1,13 @@
 """
 금융 뉴스 텍스트에서 리스크 태그를 추출하는 모듈.
 규칙 기반(키워드 매핑) 방식으로 리스크 유형을 분류합니다.
+
+RL 관측공간 연동용 3종 태그("규제변경" / "실적쇼크" / "급등락")와
+이를 이진 벡터로 변환하는 get_risk_vector()를 포함합니다.
 """
 from typing import Dict, List
+
+import numpy as np
 
 # 키워드 → 태그 매핑
 # 동일 태그를 가리키는 키워드를 복수로 등록할 수 있습니다.
@@ -80,6 +85,65 @@ def tag_severity(tag: str) -> str:
     if tag in _MEDIUM_TAGS:
         return "MEDIUM"
     return "LOW"
+
+
+# ─────────────────────────────────────────────
+# RL 관측공간 연동 — 3종 태그
+# ─────────────────────────────────────────────
+
+# RL 환경(trading_env.py)과 공유하는 고정 태그 순서 (변경 시 이문정과 협의 필요)
+RL_RISK_TAGS: List[str] = ["규제변경", "실적쇼크", "급등락"]
+
+_RL_KEYWORD_MAP: Dict[str, List[str]] = {
+    "규제변경": ["규제변경", "규정 변경", "규제 강화", "법 개정", "법개정", "금융 규제", "규제 개편"],
+    "실적쇼크": ["실적쇼크", "어닝쇼크", "실적 쇼크", "실적 충격", "실적 부진", "영업손실", "어닝 쇼크"],
+    "급등락":   ["급등락", "급등", "급락", "폭등", "폭락", "급변동", "급변"],
+}
+
+
+def extract_rl_risk_tags(text: str) -> List[str]:
+    """
+    RL 관측공간 연동용 3종 리스크 태그를 추출합니다.
+
+    Args:
+        text: 분석할 금융 뉴스 텍스트.
+
+    Returns:
+        감지된 태그 리스트. 원소는 RL_RISK_TAGS 내 값만 포함, 정렬됨.
+
+    Example:
+        >>> extract_rl_risk_tags("금융당국이 가상자산 규제를 강화했다.")
+        ['규제변경']
+    """
+    if not text:
+        return []
+    found: set = set()
+    for tag, keywords in _RL_KEYWORD_MAP.items():
+        if any(kw in text for kw in keywords):
+            found.add(tag)
+    return sorted(found)
+
+
+def get_risk_vector(tags: List[str]) -> np.ndarray:
+    """
+    RL 관측공간 연동용 3차원 이진 벡터를 반환합니다.
+
+    각 차원은 RL_RISK_TAGS 순서에 대응하며, 해당 태그가 있으면 1.0, 없으면 0.0입니다.
+
+    Args:
+        tags: extract_rl_risk_tags() 결과 또는 동일 형식의 태그 리스트.
+
+    Returns:
+        np.ndarray shape=(3,), dtype=float32.
+
+    Example:
+        >>> get_risk_vector(["급등락"])
+        array([0., 0., 1.], dtype=float32)
+    """
+    return np.array(
+        [1.0 if t in tags else 0.0 for t in RL_RISK_TAGS],
+        dtype=np.float32,
+    )
 
 
 def summarize_risk_profile(tags: List[str]) -> str:

--- a/src/rl/metrics.py
+++ b/src/rl/metrics.py
@@ -1,0 +1,316 @@
+"""
+포트폴리오 성과 지표 계산 모듈.
+
+12개 지표 함수와 통합 함수 calculate_all_metrics()를 제공합니다.
+모든 함수는 일별 로그수익률 pd.Series를 입력으로 받습니다.
+실제 계산 로직은 Sprint 3에서 완성 예정이며, 현재는 뼈대(stub) 구현입니다.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "cumulative_return",
+    "cagr",
+    "annualized_volatility",
+    "var_95",
+    "cvar_95",
+    "mdd",
+    "sharpe_ratio",
+    "sortino_ratio",
+    "calmar_ratio",
+    "alpha",
+    "beta",
+    "information_ratio",
+    "calculate_all_metrics",
+]
+
+_TRADING_DAYS = 252
+
+
+# ─────────────────────────────────────────────
+# 수익률
+# ─────────────────────────────────────────────
+
+
+def cumulative_return(returns: pd.Series) -> float:
+    """
+    누적 수익률을 계산합니다.
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        누적 수익률 (예: 0.25 = 25%).
+    """
+    if returns.empty:
+        return 0.0
+    return float(np.expm1(returns.sum()))
+
+
+def cagr(returns: pd.Series, years: float) -> float:
+    """
+    연평균 복합 성장률(CAGR)을 계산합니다.
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+        years: 기간(년). 0이면 0.0 반환.
+
+    Returns:
+        CAGR (예: 0.12 = 12%).
+    """
+    if returns.empty or years <= 0:
+        return 0.0
+    total = cumulative_return(returns)
+    return float((1 + total) ** (1 / years) - 1)
+
+
+# ─────────────────────────────────────────────
+# 리스크
+# ─────────────────────────────────────────────
+
+
+def annualized_volatility(returns: pd.Series) -> float:
+    """
+    연환산 변동성(표준편차)을 계산합니다.
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        연환산 변동성 (예: 0.18 = 18%).
+    """
+    if returns.empty or len(returns) < 2:
+        return 0.0
+    return float(returns.std(ddof=1) * np.sqrt(_TRADING_DAYS))
+
+
+def var_95(returns: pd.Series) -> float:
+    """
+    역사적 시뮬레이션 기반 95% VaR을 계산합니다 (손실은 양수).
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        VaR (예: 0.02 = 하루 최대 손실 2%).
+    """
+    if returns.empty:
+        return 0.0
+    return float(-np.percentile(returns, 5))
+
+
+def cvar_95(returns: pd.Series) -> float:
+    """
+    95% CVaR(Expected Shortfall)을 계산합니다 (손실은 양수).
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        CVaR (예: 0.03 = 평균 꼬리 손실 3%).
+    """
+    if returns.empty:
+        return 0.0
+    cutoff = np.percentile(returns, 5)
+    tail = returns[returns <= cutoff]
+    if tail.empty:
+        return 0.0
+    return float(-tail.mean())
+
+
+def mdd(returns: pd.Series) -> float:
+    """
+    최대 낙폭(Maximum Drawdown)을 계산합니다 (양수로 반환).
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        MDD (예: 0.30 = 최대 30% 하락).
+    """
+    if returns.empty:
+        return 0.0
+    cumulative = (1 + returns).cumprod()
+    rolling_max = cumulative.cummax()
+    drawdown = (cumulative - rolling_max) / rolling_max
+    return float(-drawdown.min())
+
+
+# ─────────────────────────────────────────────
+# 위험조정 수익률
+# ─────────────────────────────────────────────
+
+
+def sharpe_ratio(returns: pd.Series, rf: float = 0.0) -> float:
+    """
+    샤프 비율을 계산합니다.
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+        rf: 일별 무위험 수익률 (기본값 0).
+
+    Returns:
+        연환산 샤프 비율.
+    """
+    if returns.empty or len(returns) < 2:
+        return 0.0
+    excess = returns - rf
+    vol = excess.std(ddof=1)
+    if vol == 0:
+        return 0.0
+    return float((excess.mean() / vol) * np.sqrt(_TRADING_DAYS))
+
+
+def sortino_ratio(returns: pd.Series, rf: float = 0.0) -> float:
+    """
+    소르티노 비율을 계산합니다 (하방 편차만 사용).
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+        rf: 일별 무위험 수익률 (기본값 0).
+
+    Returns:
+        연환산 소르티노 비율.
+    """
+    if returns.empty or len(returns) < 2:
+        return 0.0
+    excess = returns - rf
+    downside = excess[excess < 0]
+    if downside.empty:
+        return 0.0
+    downside_std = downside.std(ddof=1)
+    if downside_std == 0:
+        return 0.0
+    return float((excess.mean() / downside_std) * np.sqrt(_TRADING_DAYS))
+
+
+def calmar_ratio(returns: pd.Series) -> float:
+    """
+    칼마 비율(CAGR / MDD)을 계산합니다.
+
+    Args:
+        returns: 일별 로그수익률 시계열.
+
+    Returns:
+        칼마 비율. MDD가 0이면 0.0 반환.
+    """
+    if returns.empty:
+        return 0.0
+    years = len(returns) / _TRADING_DAYS
+    _cagr = cagr(returns, years)
+    _mdd = mdd(returns)
+    if _mdd == 0:
+        return 0.0
+    return float(_cagr / _mdd)
+
+
+# ─────────────────────────────────────────────
+# 상대 성과
+# ─────────────────────────────────────────────
+
+
+def alpha(returns: pd.Series, benchmark: pd.Series) -> float:
+    """
+    젠센 알파(Jensen's Alpha)를 계산합니다.
+
+    Args:
+        returns: 포트폴리오 일별 로그수익률.
+        benchmark: 벤치마크 일별 로그수익률.
+
+    Returns:
+        연환산 알파.
+    """
+    if returns.empty or benchmark.empty:
+        return 0.0
+    aligned_r, aligned_b = returns.align(benchmark, join="inner")
+    if len(aligned_r) < 2:
+        return 0.0
+    _beta = beta(aligned_r, aligned_b)
+    return float((aligned_r.mean() - _beta * aligned_b.mean()) * _TRADING_DAYS)
+
+
+def beta(returns: pd.Series, benchmark: pd.Series) -> float:
+    """
+    포트폴리오 베타를 계산합니다.
+
+    Args:
+        returns: 포트폴리오 일별 로그수익률.
+        benchmark: 벤치마크 일별 로그수익률.
+
+    Returns:
+        베타. 벤치마크 분산이 0이면 0.0 반환.
+    """
+    if returns.empty or benchmark.empty:
+        return 0.0
+    aligned_r, aligned_b = returns.align(benchmark, join="inner")
+    if len(aligned_r) < 2:
+        return 0.0
+    cov_matrix = np.cov(aligned_r.values, aligned_b.values)
+    bench_var = float(cov_matrix[1, 1])
+    if bench_var == 0:
+        return 0.0
+    return float(cov_matrix[0, 1] / bench_var)
+
+
+def information_ratio(returns: pd.Series, benchmark: pd.Series) -> float:
+    """
+    정보 비율(Information Ratio)을 계산합니다.
+
+    Args:
+        returns: 포트폴리오 일별 로그수익률.
+        benchmark: 벤치마크 일별 로그수익률.
+
+    Returns:
+        연환산 정보 비율. 추적오차가 0이면 0.0 반환.
+    """
+    if returns.empty or benchmark.empty:
+        return 0.0
+    aligned_r, aligned_b = returns.align(benchmark, join="inner")
+    if len(aligned_r) < 2:
+        return 0.0
+    active = aligned_r - aligned_b
+    te = active.std(ddof=1)
+    if te == 0:
+        return 0.0
+    return float((active.mean() / te) * np.sqrt(_TRADING_DAYS))
+
+
+# ─────────────────────────────────────────────
+# 통합 함수
+# ─────────────────────────────────────────────
+
+
+def calculate_all_metrics(
+    returns: pd.Series,
+    benchmark: pd.Series,
+) -> dict[str, float]:
+    """
+    12개 성과 지표를 한 번에 계산해 dict로 반환합니다.
+
+    Args:
+        returns: 포트폴리오 일별 로그수익률.
+        benchmark: 벤치마크 일별 로그수익률 (alpha/beta/IR 계산에 사용).
+
+    Returns:
+        지표명 → float 매핑 dict. 키 12개 고정:
+        cumulative_return, cagr, annualized_volatility, var_95, cvar_95,
+        mdd, sharpe_ratio, sortino_ratio, calmar_ratio, alpha, beta,
+        information_ratio.
+    """
+    years = len(returns) / _TRADING_DAYS if not returns.empty else 1.0
+    return {
+        "cumulative_return":     cumulative_return(returns),
+        "cagr":                  cagr(returns, years),
+        "annualized_volatility": annualized_volatility(returns),
+        "var_95":                var_95(returns),
+        "cvar_95":               cvar_95(returns),
+        "mdd":                   mdd(returns),
+        "sharpe_ratio":          sharpe_ratio(returns),
+        "sortino_ratio":         sortino_ratio(returns),
+        "calmar_ratio":          calmar_ratio(returns),
+        "alpha":                 alpha(returns, benchmark),
+        "beta":                  beta(returns, benchmark),
+        "information_ratio":     information_ratio(returns, benchmark),
+    }

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,15 @@
+from src.agent.graph import run_graph                                                              
+                  
+result = run_graph("삼성전자 HBM 실적 전망은?")                                                    
+  
+print("=== sources ===")                                                                           
+print(result.get("sources"))
+                                                                                                     
+print("\n=== risk_tags (3종) ===")
+print(result.get("risk_tags"))                                                                     
+                  
+print("\n=== reasoning_trace ===")
+print(result.get("reasoning_trace"))
+                                                                                                     
+print("\n=== report 미리보기 ===")
+print(result.get("response", "")[:300])  

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,15 +1,16 @@
-from src.agent.graph import run_graph                                                              
-                  
-result = run_graph("삼성전자 HBM 실적 전망은?")                                                    
-  
-print("=== sources ===")                                                                           
-print(result.get("sources"))
-                                                                                                     
-print("\n=== risk_tags (3종) ===")
-print(result.get("risk_tags"))                                                                     
-                  
-print("\n=== reasoning_trace ===")
-print(result.get("reasoning_trace"))
-                                                                                                     
-print("\n=== report 미리보기 ===")
-print(result.get("response", "")[:300])  
+import pytest
+
+from src.agent.graph import run_graph
+
+
+@pytest.mark.integration
+def test_run_graph_returns_required_keys():
+    result = run_graph("삼성전자 HBM 실적 전망은?")
+
+    assert "response" in result
+    assert "sources" in result
+    assert "rl_risk_tags" in result
+    assert "reasoning_trace" in result
+    assert isinstance(result["sources"], list)
+    assert isinstance(result["rl_risk_tags"], list)
+    assert len(result.get("response", "")) > 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,19 @@
+                                                                                                    
+import numpy as np
+import pandas as pd                                                                                
+from src.rl.metrics import calculate_all_metrics, sharpe_ratio, mdd
+                                                                                                     
+rng = np.random.default_rng(42)                                                                    
+portfolio = pd.Series(rng.normal(0.0005, 0.015, 252))                                              
+benchmark = pd.Series(rng.normal(0.0003, 0.010, 252))                                              
+                  
+print("=== 개별 함수 ===")                                                                         
+print("샤프비율:", round(sharpe_ratio(portfolio), 4))
+print("MDD     :", round(mdd(portfolio), 4))                                                       
+                                                                                                     
+print("\n=== calculate_all_metrics ===")
+result = calculate_all_metrics(portfolio, benchmark)                                               
+print(f"키 개수: {len(result)}  (12이어야 함)")
+for k, v in result.items():                                                                        
+    print(f"  {k:<25}: {v:.4f}")
+                                    

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,19 +1,57 @@
-                                                                                                    
 import numpy as np
-import pandas as pd                                                                                
-from src.rl.metrics import calculate_all_metrics, sharpe_ratio, mdd
-                                                                                                     
-rng = np.random.default_rng(42)                                                                    
-portfolio = pd.Series(rng.normal(0.0005, 0.015, 252))                                              
-benchmark = pd.Series(rng.normal(0.0003, 0.010, 252))                                              
-                  
-print("=== 개별 함수 ===")                                                                         
-print("샤프비율:", round(sharpe_ratio(portfolio), 4))
-print("MDD     :", round(mdd(portfolio), 4))                                                       
-                                                                                                     
-print("\n=== calculate_all_metrics ===")
-result = calculate_all_metrics(portfolio, benchmark)                                               
-print(f"키 개수: {len(result)}  (12이어야 함)")
-for k, v in result.items():                                                                        
-    print(f"  {k:<25}: {v:.4f}")
-                                    
+import pandas as pd
+import pytest
+
+from src.rl.metrics import calculate_all_metrics, mdd, sharpe_ratio
+
+_EXPECTED_METRIC_KEYS = {
+    "cumulative_return",
+    "cagr",
+    "annualized_volatility",
+    "var_95",
+    "cvar_95",
+    "mdd",
+    "sharpe_ratio",
+    "sortino_ratio",
+    "calmar_ratio",
+    "alpha",
+    "beta",
+    "information_ratio",
+}
+
+
+@pytest.fixture
+def sample_series():
+    rng = np.random.default_rng(42)
+    portfolio = pd.Series(rng.normal(0.0005, 0.015, 252))
+    benchmark = pd.Series(rng.normal(0.0003, 0.010, 252))
+    return portfolio, benchmark
+
+
+def test_sharpe_ratio_is_finite(sample_series):
+    portfolio, _ = sample_series
+    assert np.isfinite(sharpe_ratio(portfolio))
+
+
+def test_mdd_is_non_negative(sample_series):
+    portfolio, _ = sample_series
+    assert mdd(portfolio) >= 0.0
+
+
+def test_calculate_all_metrics_returns_12_keys(sample_series):
+    portfolio, benchmark = sample_series
+    result = calculate_all_metrics(portfolio, benchmark)
+    assert len(result) == 12
+
+
+def test_calculate_all_metrics_has_expected_keys(sample_series):
+    portfolio, benchmark = sample_series
+    result = calculate_all_metrics(portfolio, benchmark)
+    assert set(result.keys()) == _EXPECTED_METRIC_KEYS
+
+
+def test_calculate_all_metrics_all_finite(sample_series):
+    portfolio, benchmark = sample_series
+    result = calculate_all_metrics(portfolio, benchmark)
+    for key, val in result.items():
+        assert np.isfinite(val), f"{key} 값이 유한하지 않음: {val}"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,28 @@
+from src.agent.nodes import analyst_node
+                                                                                                     
+state = {       
+  "query": "삼성전자 반도체 전망은?",                                                            
+  "context": "[문서 1] 삼성전자 HBM 수요 급증\n날짜: 2025-01-01\n본문: HBM 공급 부족으로 실적 개선 기대\n출처: https://example.com/news/1",                                                      
+  "documents": [{"content": "HBM 수요 급증 실적쇼크 우려", "metadata": {"url": "https://example.com/news/1"}}],                                                                   
+  "risk_tags": ["변동성_리스크"],
+  "messages": ["[THINK][planner] 플랜 완료", 
+  "[THINK][researcher] 검색 완료"],                   
+  "retry_count": 0,                                                                              
+  "needs_research_retry": False,                                                                 
+  "sources": [],                                                                                 
+  "reasoning_trace": "",                                                                         
+  }               
+                                                                                                     
+result = analyst_node(state)
+
+print("=== sources ===")
+print(result["sources"])
+                                                                                                     
+print("\n=== risk_tags (3종) ===")
+print(result["risk_tags"])                                                                         
+                                                                                                     
+print("\n=== reasoning_trace ===")
+print(result["reasoning_trace"])                                                                   
+                  
+print("\n=== report 미리보기 ===")
+print(result["response"][:300])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,28 +1,28 @@
-from src.agent.nodes import analyst_node
-                                                                                                     
-state = {       
-  "query": "삼성전자 반도체 전망은?",                                                            
-  "context": "[문서 1] 삼성전자 HBM 수요 급증\n날짜: 2025-01-01\n본문: HBM 공급 부족으로 실적 개선 기대\n출처: https://example.com/news/1",                                                      
-  "documents": [{"content": "HBM 수요 급증 실적쇼크 우려", "metadata": {"url": "https://example.com/news/1"}}],                                                                   
-  "risk_tags": ["변동성_리스크"],
-  "messages": ["[THINK][planner] 플랜 완료", 
-  "[THINK][researcher] 검색 완료"],                   
-  "retry_count": 0,                                                                              
-  "needs_research_retry": False,                                                                 
-  "sources": [],                                                                                 
-  "reasoning_trace": "",                                                                         
-  }               
-                                                                                                     
-result = analyst_node(state)
+import pytest
 
-print("=== sources ===")
-print(result["sources"])
-                                                                                                     
-print("\n=== risk_tags (3종) ===")
-print(result["risk_tags"])                                                                         
-                                                                                                     
-print("\n=== reasoning_trace ===")
-print(result["reasoning_trace"])                                                                   
-                  
-print("\n=== report 미리보기 ===")
-print(result["response"][:300])
+from src.agent.nodes import analyst_node
+
+
+@pytest.mark.integration
+def test_analyst_node_returns_required_keys():
+    state = {
+        "query": "삼성전자 반도체 전망은?",
+        "context": "[문서 1] 삼성전자 HBM 수요 급증\n날짜: 2025-01-01\n본문: HBM 공급 부족으로 실적 개선 기대\n출처: https://example.com/news/1",
+        "documents": [{"content": "HBM 수요 급증 실적쇼크 우려", "metadata": {"url": "https://example.com/news/1"}}],
+        "risk_tags": ["변동성_리스크"],
+        "messages": ["[THINK][planner] 플랜 완료", "[THINK][researcher] 검색 완료"],
+        "retry_count": 0,
+        "needs_research_retry": False,
+        "sources": [],
+        "reasoning_trace": "",
+    }
+
+    result = analyst_node(state)
+
+    assert "response" in result
+    assert "sources" in result
+    assert "rl_risk_tags" in result
+    assert "reasoning_trace" in result
+    assert isinstance(result["rl_risk_tags"], list)
+    assert isinstance(result["sources"], list)
+    assert len(result["response"]) > 0

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,21 @@
+from src.agent.risk_tags import extract_rl_risk_tags, get_risk_vector, RL_RISK_TAGS                
+                                                                                                     
+  # 케이스 1: 규제변경 + 급등락                                                                      
+text1 = "금융위원회가 가상자산 규제변경을 발표하자 시장이 급락했다"
+tags1 = extract_rl_risk_tags(text1)                                                                
+print("케이스1 태그:", tags1)                                                                      
+print("케이스1 벡터:", get_risk_vector(tags1))  # [1. 0. 1.] 기대                                  
+                                                                                                     
+  # 케이스 2: 실적쇼크 + 급등락
+text2 = "삼성전자 어닝쇼크로 주가 급락"                                                            
+tags2 = extract_rl_risk_tags(text2)                                                                
+print("케이스2 태그:", tags2)
+print("케이스2 벡터:", get_risk_vector(tags2))  # [0. 1. 1.] 기대                                  
+                                                                                                     
+  # 케이스 3: 빈 텍스트
+tags3 = extract_rl_risk_tags("")                                                                   
+print("케이스3 태그:", tags3)
+print("케이스3 벡터:", get_risk_vector(tags3))  # [0. 0. 0.] 기대                                  
+   
+  # 태그 순서 확인                                                                                   
+print("태그 순서:", RL_RISK_TAGS)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,21 +1,38 @@
-from src.agent.risk_tags import extract_rl_risk_tags, get_risk_vector, RL_RISK_TAGS                
-                                                                                                     
-  # 케이스 1: 규제변경 + 급등락                                                                      
-text1 = "금융위원회가 가상자산 규제변경을 발표하자 시장이 급락했다"
-tags1 = extract_rl_risk_tags(text1)                                                                
-print("케이스1 태그:", tags1)                                                                      
-print("케이스1 벡터:", get_risk_vector(tags1))  # [1. 0. 1.] 기대                                  
-                                                                                                     
-  # 케이스 2: 실적쇼크 + 급등락
-text2 = "삼성전자 어닝쇼크로 주가 급락"                                                            
-tags2 = extract_rl_risk_tags(text2)                                                                
-print("케이스2 태그:", tags2)
-print("케이스2 벡터:", get_risk_vector(tags2))  # [0. 1. 1.] 기대                                  
-                                                                                                     
-  # 케이스 3: 빈 텍스트
-tags3 = extract_rl_risk_tags("")                                                                   
-print("케이스3 태그:", tags3)
-print("케이스3 벡터:", get_risk_vector(tags3))  # [0. 0. 0.] 기대                                  
-   
-  # 태그 순서 확인                                                                                   
-print("태그 순서:", RL_RISK_TAGS)
+import numpy as np
+
+from src.agent.risk_tags import RL_RISK_TAGS, extract_rl_risk_tags, get_risk_vector
+
+
+def test_regulation_and_surge_detected():
+    tags = extract_rl_risk_tags("금융위원회가 가상자산 규제변경을 발표하자 시장이 급락했다")
+    assert "규제변경" in tags
+    assert "급등락" in tags
+    vec = get_risk_vector(tags)
+    assert vec[0] == 1.0
+    assert vec[2] == 1.0
+
+
+def test_earnings_shock_and_surge_detected():
+    tags = extract_rl_risk_tags("삼성전자 어닝쇼크로 주가 급락")
+    assert "실적쇼크" in tags
+    assert "급등락" in tags
+    vec = get_risk_vector(tags)
+    assert vec[1] == 1.0
+    assert vec[2] == 1.0
+
+
+def test_empty_text_returns_no_tags():
+    tags = extract_rl_risk_tags("")
+    assert tags == []
+    vec = get_risk_vector(tags)
+    assert list(vec) == [0.0, 0.0, 0.0]
+
+
+def test_risk_vector_shape_and_dtype():
+    vec = get_risk_vector(["규제변경"])
+    assert vec.shape == (3,)
+    assert vec.dtype == np.float32
+
+
+def test_rl_risk_tags_order():
+    assert RL_RISK_TAGS == ["규제변경", "실적쇼크", "급등락"]


### PR DESCRIPTION
## 관련 이슈
closes #8, closes #9, closes #10

## 작업 내용
Sprint 2 구현 완료 — 강유영 담당 모듈 전체.

- **[항목 1]** RL 리스크 태그 모듈 (`risk_tags.py`) — 3종 태그 + `get_risk_vector()`
- **[항목 2]** 성과지표 모듈 (`metrics.py`) — 12개 지표 함수 + `calculate_all_metrics()`
- **[항목 3]** LangGraph 에이전트 출력 구조화 (`nodes.py`, `graph.py`) — `sources`·`reasoning_trace` 추가, analyst 구조화
- **[항목 4]** LangGraph 전체 워크플로우 실행 확인 (`graph.py`)
- **[항목 5]** Streamlit 6탭 대시보드 (`apps/dashboard/app.py`) — ECharts + `st.navigation` 사이드바 네비게이션

## 변경된 파일
| 파일 | 변경 내용 |
|------|---------|
| `src/agent/risk_tags.py` | RL 3종 태그(`규제변경`/`실적쇼크`/`급등락`) + `get_risk_vector()` 추가 |
| `src/agent/nodes.py` | `AgentState`에 `sources`·`reasoning_trace` 필드 추가, `analyst_node` 구조화 출력 |
| `src/agent/graph.py` | `run_graph()` 초기 state 필드 반영 |
| `src/rl/metrics.py` | 신규 — 12개 성과지표 함수 + `calculate_all_metrics()` |
| `apps/dashboard/app.py` | 신규 — ECharts 기반 6탭 대시보드, `st.navigation` 사이드바 네비게이션 |
| `requirements.txt` | `streamlit-echarts>=0.6.0` 추가 |
| `tests/test_risk.py` | 신규 — RL 태그 추출·벡터 변환 수동 테스트 |
| `tests/test_metrics.py` | 신규 — 성과지표 계산 수동 테스트 |
| `tests/test_nodes.py` | 신규 — AgentState 구조 및 analyst_node 수동 테스트 |
| `tests/test_graph.py` | 신규 — LangGraph 전체 워크플로우 수동 테스트 |

## 테스트 결과

### 항목 1 — RL 리스크 태그 (`tests/test_risk.py`)
<img width="653" height="134" alt="스크린샷 2026-04-30 오후 7 24 41" src="https://github.com/user-attachments/assets/1594bb96-5dcd-4a90-b88b-8c5f80684198" />

### 항목 2 — 성과지표 (`tests/test_metrics.py`)
<img width="653" height="272" alt="스크린샷 2026-04-30 오후 7 26 56" src="https://github.com/user-attachments/assets/4526f0b0-7665-4923-a165-9320e1792523" />

### 항목 3 — analyst_node, AgentState 구조 확인 (`tests/test_nodes.py`, OpenAI 사용)
<img width="721" height="344" alt="스크린샷 2026-04-30 오후 7 29 57" src="https://github.com/user-attachments/assets/9680b31f-48b0-4948-a156-0db0f9c4bac6" />

### 항목 4 — LangGraph 전체 워크플로우 (`tests/test_graph.py`)
<img width="721" height="654" alt="스크린샷 2026-04-30 오후 7 34 00" src="https://github.com/user-attachments/assets/9496055f-8c45-4ef3-b8ef-7c6238330525" />

### 항목 5 — Streamlit 대시보드 화면 (`apps/dashboard/app.py`)
<img width="1421" height="770" alt="스크린샷 2026-05-05 오후 2 05 58" src="https://github.com/user-attachments/assets/a6125857-b6f4-4054-8ab8-5a8c3fe23c7c" />

## 체크리스트
- [x] 담당 파일 외 다른 팀원 파일 무단 수정 없음
- [x] `.env` 파일 커밋 안 함
- [x] 새 함수/클래스에 docstring 작성
- [x] 테스트 통과 확인 (`pytest`)
- [x] PR 대상 브랜치가 `dev`인지 확인 (셀프 merge 금지)

## 기타 참고 사항

> ### ⚠️ 필수 패키지 설치!! 
> 대시보드 실행 전 아래 명령어를 반드시 실행해주세요 !! (템플릿을 새로 가져와서 구현한거라 패키지 설치 해야합니다.)
> ```bash
> pip install streamlit-echarts
> ```

- **대시보드 사이드바 필터 (분석 기간 · 비교 전략)**: Sprint 3에서 `/backtest` · `/optimize` API 연결 시 실제 파라미터로 동작 예정. 현재는 UI 자리 선점 상태.
- `apps/api/` 미연결 상태: 대시보드는 FastAPI 미완성 구간에서 mock 데이터로 자동 폴백
- `src/rl/metrics.py` 실계산 로직은 Sprint 3에서 완성 예정 (현재 뼈대 구현)
- `.streamlit/config.toml` 은 `.gitignore` 적용으로 로컬 전용 (테마 설정)
- `get_risk_vector()` 인터페이스는 이문정 `trading_env.py` 연동 예정 — shape=(3,) float32 고정