### PR TITLE
feat: FastAPI Sprint 2 endpoint contracts complete

### DIFF
--- a/apps/api/routers/health.py
+++ b/apps/api/routers/health.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from apps.api.config import settings
 from apps.api.schemas import HealthResponse
+from apps.api.services import build_module_statuses
 
 router = APIRouter(tags=["health"])
 
@@ -18,10 +19,5 @@ def health_check() -> HealthResponse:
             "port": settings.API_PORT,
             "log_level": settings.LOG_LEVEL,
         },
-        modules={
-            "data": "ready",
-            "rl": "fallback",
-            "rag": "fallback",
-            "shap": "fallback",
-        },
+        modules=build_module_statuses(),
     )

--- a/apps/api/routers/optimize.py
+++ b/apps/api/routers/optimize.py
@@ -11,4 +11,8 @@ router = APIRouter(tags=["portfolio"])
 @router.post("/optimize", response_model=OptimizeResponse)
 def optimize_portfolio(request: OptimizeRequest) -> OptimizeResponse:
     """Return normalized portfolio weights."""
-    return build_fallback_portfolio(request.tickers, request.risk_profile)
+    return build_fallback_portfolio(
+        tickers=request.tickers,
+        risk_profile=request.risk_profile,
+        risk_aversion=request.risk_aversion,
+    )

--- a/apps/api/routers/research.py
+++ b/apps/api/routers/research.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 
 from apps.api.schemas import ResearchRequest, ResearchResponse
-from apps.api.services import build_fallback_research
+from apps.api.services import build_research_response
 
 router = APIRouter(tags=["research"])
 
@@ -11,4 +11,4 @@ router = APIRouter(tags=["research"])
 @router.post("/research", response_model=ResearchResponse)
 def research_question(request: ResearchRequest) -> ResearchResponse:
     """Return investment research report data."""
-    return build_fallback_research(request.question)
+    return build_research_response(request.question)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -29,6 +29,15 @@ class OptimizeRequest(BaseModel):
 
     tickers: list[str] | None = Field(default=None, min_length=1)
     risk_profile: RiskProfile = "balanced"
+    risk_aversion: float | None = Field(default=None, gt=0)
+
+
+class ReturnSeries(BaseModel):
+    """Chart-ready cumulative return series."""
+
+    date: list[str]
+    portfolio: list[float]
+    benchmark: list[float]
 
 
 class OptimizeResponse(BaseModel):
@@ -40,6 +49,7 @@ class OptimizeResponse(BaseModel):
     risk_profile: RiskProfile
     expected_return: float
     expected_volatility: float
+    returns: ReturnSeries
     message: str
 
 
@@ -63,9 +73,12 @@ class ExplainResponse(BaseModel):
 
     status: EndpointStatus
     date: str | None
+    target_date: str | None
     base_value: float
     prediction: float
     feature_contributions: list[FeatureContribution]
+    feature_names: list[str]
+    shap_values: list[float]
     message: str
 
 
@@ -103,4 +116,15 @@ class BacktestResponse(BaseModel):
     metrics: dict[str, float]
     anova: list[AnovaResult]
     benchmark: str
+    dates: list[str]
+    rewards: list[float]
+    wf_cum: list[float]
+    bm_cum: list[float]
+    wf_spark: list[float]
+    sharpe_spark: list[float]
+    drawdown: list[float]
+    var_95: float
+    cvar_95: float
+    mdd: float
+    safeguard: dict[str, bool | float | str | None]
     message: str

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -7,15 +7,27 @@ small: replace the fallback body, keep the response schema.
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from apps.api.config import settings
 from apps.api.schemas import (
     AnovaResult,
     BacktestResponse,
     ExplainResponse,
     FeatureContribution,
     OptimizeResponse,
+    ReturnSeries,
     ResearchResponse,
     RiskProfile,
 )
+
+RETURNS_PATH = Path("data/processed/returns.parquet")
+FEATURES_PATH = Path("data/processed/features.parquet")
+TRADING_DAYS = 252
 
 DEFAULT_TICKERS: list[str] = [
     "SPY",
@@ -34,48 +46,80 @@ DEFAULT_TICKERS: list[str] = [
 def build_fallback_portfolio(
     tickers: list[str] | None = None,
     risk_profile: RiskProfile = "balanced",
+    risk_aversion: float | None = None,
 ) -> OptimizeResponse:
     """Return deterministic normalized weights until the PPO model is connected."""
     selected_tickers = tickers or DEFAULT_TICKERS
-    raw_weights = _risk_adjusted_raw_weights(selected_tickers, risk_profile)
+    raw_weights = _risk_adjusted_raw_weights(selected_tickers, risk_profile, risk_aversion)
     total_weight = sum(raw_weights.values())
     weights = {ticker: weight / total_weight for ticker, weight in raw_weights.items()}
+    return_series, expected_return, expected_volatility = _build_return_series(weights)
 
     return OptimizeResponse(
         status="fallback",
         tickers=selected_tickers,
         weights=weights,
         risk_profile=risk_profile,
-        expected_return=0.084 if risk_profile == "balanced" else _profile_return(risk_profile),
-        expected_volatility=(
-            0.132 if risk_profile == "balanced" else _profile_volatility(risk_profile)
-        ),
+        expected_return=expected_return or _profile_return(risk_profile),
+        expected_volatility=expected_volatility or _profile_volatility(risk_profile),
+        returns=return_series,
         message="PPO 모델 연결 전 deterministic fallback 포트폴리오입니다.",
     )
 
 
 def build_fallback_explanation(date: str | None, top_k: int) -> ExplainResponse:
     """Return SHAP-like feature contributions for dashboard integration."""
-    features = [
-        FeatureContribution(feature="SPY_return_30d", value=0.018, contribution=0.031),
-        FeatureContribution(feature="TLT_return_30d", value=-0.011, contribution=-0.014),
-        FeatureContribution(feature="QQQ_RSI", value=61.2, contribution=0.019),
-        FeatureContribution(feature="GLD_MACD_signal", value=0.004, contribution=0.012),
-        FeatureContribution(feature="069500_return_30d", value=0.009, contribution=0.008),
-        FeatureContribution(feature="VNQ_RSI", value=47.6, contribution=-0.006),
-        FeatureContribution(feature="EEM_MACD_signal", value=-0.003, contribution=-0.005),
-        FeatureContribution(feature="114260_return_30d", value=0.006, contribution=0.004),
-    ]
+    features = _feature_contributions_from_parquet(date, top_k) or _static_feature_contributions()
 
     selected = features[:top_k]
     prediction = 0.05 + sum(item.contribution for item in selected)
+    target_date = date or _latest_feature_date()
     return ExplainResponse(
         status="fallback",
         date=date,
+        target_date=target_date,
         base_value=0.05,
         prediction=round(prediction, 6),
         feature_contributions=selected,
+        feature_names=[item.feature for item in selected],
+        shap_values=[item.contribution for item in selected],
         message="SHAP 모듈 연결 전 feature contribution fallback입니다.",
+    )
+
+
+def run_graph(question: str) -> dict[str, Any]:
+    """Import and run LangGraph lazily so API import stays safe without an API key."""
+    from src.agent.graph import run_graph as _run_graph
+
+    return _run_graph(question)
+
+
+def build_research_response(question: str) -> ResearchResponse:
+    """Run LangGraph when configured, otherwise return the deterministic fallback."""
+    if not settings.OPENAI_API_KEY:
+        return build_fallback_research(question)
+
+    try:
+        state = run_graph(question)
+    except Exception:
+        return build_fallback_research(question)
+
+    report = str(state.get("response") or "").strip()
+    if not report:
+        return build_fallback_research(question)
+
+    messages = state.get("messages") or []
+    reasoning_trace = state.get("reasoning_trace") or "\n".join(str(item) for item in messages)
+    risk_tags = state.get("rl_risk_tags") or state.get("risk_tags") or _infer_risk_tags(question)
+    sources = [str(source) for source in state.get("sources", []) if source]
+
+    return ResearchResponse(
+        status="ready",
+        question=question,
+        report=report,
+        sources=sources or ["https://github.com/AI-Robo-Advisor/rl-rag-roboadvisor"],
+        reasoning_trace=reasoning_trace,
+        risk_tags=[str(tag) for tag in risk_tags],
     )
 
 
@@ -102,22 +146,266 @@ def build_fallback_research(question: str) -> ResearchResponse:
 
 
 def build_fallback_backtest() -> BacktestResponse:
-    """Return the MVP metric and ANOVA contract with deterministic values."""
-    metrics = {
-        "cumulative_return": 0.184,
-        "cagr": 0.087,
-        "annualized_volatility": 0.132,
-        "var_95": -0.021,
-        "cvar_95": -0.034,
-        "max_drawdown": -0.118,
-        "sharpe_ratio": 0.74,
-        "sortino_ratio": 1.08,
-        "calmar_ratio": 0.74,
-        "alpha": 0.031,
-        "beta": 0.86,
-        "information_ratio": 0.42,
+    """Return metric output from available data plus fallback ANOVA summaries."""
+    metrics, dates, wf_cum, bm_cum, rewards, drawdown, sharpe_spark = _build_backtest_payload()
+    anova = _fallback_anova()
+    current_mdd = float(metrics.get("mdd", 0.0))
+    return BacktestResponse(
+        status="fallback",
+        metrics=metrics,
+        anova=anova,
+        benchmark="SPY",
+        dates=dates,
+        rewards=rewards,
+        wf_cum=wf_cum,
+        bm_cum=bm_cum,
+        wf_spark=wf_cum[-50:],
+        sharpe_spark=sharpe_spark,
+        drawdown=drawdown,
+        var_95=float(metrics.get("var_95", 0.0)),
+        cvar_95=float(metrics.get("cvar_95", 0.0)),
+        mdd=current_mdd,
+        safeguard={
+            "active": False,
+            "triggered_at": None,
+            "current_drawdown": abs(drawdown[-1]) if drawdown else current_mdd,
+        },
+        message="Walk-Forward 백테스트 모듈 연결 전 fallback 결과입니다.",
+    )
+
+
+def build_module_statuses() -> dict[str, str]:
+    """Return runtime readiness using only files and modules available locally."""
+    return {
+        "data": "ready" if _can_load_data_files() else "fallback",
+        "rl": "fallback",
+        "rag": "ready" if settings.OPENAI_API_KEY else "fallback",
+        "shap": "fallback",
+        "backtest": "fallback",
     }
-    anova = [
+
+
+def _risk_adjusted_raw_weights(
+    tickers: list[str],
+    risk_profile: RiskProfile,
+    risk_aversion: float | None,
+) -> dict[str, float]:
+    """Build simple deterministic tilts by risk profile."""
+    raw_weights = {ticker: 1.0 for ticker in tickers}
+    if risk_aversion is not None:
+        defensive_tilt = min(max(risk_aversion, 0.1), 5.0) / 2.0
+        growth_tilt = max(0.1, 2.5 / max(risk_aversion, 0.1)) / 2.0
+        for ticker in ("TLT", "GLD", "114260"):
+            if ticker in raw_weights:
+                raw_weights[ticker] += defensive_tilt
+        for ticker in ("SPY", "QQQ", "IWM", "EEM"):
+            if ticker in raw_weights:
+                raw_weights[ticker] += growth_tilt
+    elif risk_profile == "conservative":
+        for ticker in ("TLT", "GLD", "114260"):
+            if ticker in raw_weights:
+                raw_weights[ticker] += 0.5
+    elif risk_profile == "aggressive":
+        for ticker in ("SPY", "QQQ", "IWM", "EEM"):
+            if ticker in raw_weights:
+                raw_weights[ticker] += 0.5
+    return raw_weights
+
+
+def _profile_return(risk_profile: RiskProfile) -> float:
+    """Expected annual return placeholder by risk profile."""
+    return {"conservative": 0.052, "balanced": 0.084, "aggressive": 0.112}[risk_profile]
+
+
+def _profile_volatility(risk_profile: RiskProfile) -> float:
+    """Expected annual volatility placeholder by risk profile."""
+    return {"conservative": 0.085, "balanced": 0.132, "aggressive": 0.184}[risk_profile]
+
+
+def _build_return_series(
+    weights: dict[str, float],
+) -> tuple[ReturnSeries, float | None, float | None]:
+    """Build cumulative portfolio and benchmark series from returns.parquet when available."""
+    try:
+        returns = pd.read_parquet(RETURNS_PATH)
+        usable = [ticker for ticker in weights if ticker in returns.columns]
+        if not usable:
+            return _static_return_series(), None, None
+
+        usable_weights = pd.Series({ticker: weights[ticker] for ticker in usable}, dtype=float)
+        usable_weights = usable_weights / usable_weights.sum()
+        portfolio_returns = returns[usable].mul(usable_weights, axis=1).sum(axis=1)
+        benchmark_returns = returns["SPY"] if "SPY" in returns.columns else returns[usable[0]]
+
+        portfolio_cum = np.exp(portfolio_returns.cumsum())
+        benchmark_cum = np.exp(benchmark_returns.cumsum())
+        years = len(portfolio_returns) / TRADING_DAYS
+        expected_return = float(portfolio_cum.iloc[-1] ** (1 / years) - 1) if years > 0 else 0.0
+        expected_volatility = float(portfolio_returns.std(ddof=1) * np.sqrt(TRADING_DAYS))
+        return (
+            ReturnSeries(
+                date=[index.strftime("%Y-%m-%d") for index in returns.index],
+                portfolio=_finite_float_list(portfolio_cum),
+                benchmark=_finite_float_list(benchmark_cum),
+            ),
+            round(expected_return, 6),
+            round(expected_volatility, 6),
+        )
+    except (OSError, ValueError, KeyError, ImportError):
+        return _static_return_series(), None, None
+
+
+def _static_return_series() -> ReturnSeries:
+    """Return deterministic chart data when parquet data is unavailable."""
+    dates = pd.date_range("2024-01-01", periods=252, freq="B")
+    portfolio = np.cumprod(np.full(len(dates), 1.00035))
+    benchmark = np.cumprod(np.full(len(dates), 1.0002))
+    return ReturnSeries(
+        date=[item.strftime("%Y-%m-%d") for item in dates],
+        portfolio=_finite_float_list(portfolio),
+        benchmark=_finite_float_list(benchmark),
+    )
+
+
+def _feature_contributions_from_parquet(
+    requested_date: str | None,
+    top_k: int,
+) -> list[FeatureContribution] | None:
+    """Build deterministic SHAP-like contributions from the nearest feature row."""
+    try:
+        features = pd.read_parquet(FEATURES_PATH)
+        if features.empty:
+            return None
+        if requested_date:
+            selected_date = pd.Timestamp(requested_date)
+            candidates = features.loc[features.index <= selected_date]
+            row = candidates.iloc[-1] if not candidates.empty else features.iloc[0]
+        else:
+            row = features.iloc[-1]
+    except (OSError, ValueError, ImportError):
+        return None
+
+    selected_columns = row.abs().sort_values(ascending=False).head(top_k).index
+    return [
+        FeatureContribution(
+            feature=str(column),
+            value=round(float(row[column]), 6),
+            contribution=round(float(row[column]) * 0.01, 6),
+        )
+        for column in selected_columns
+    ]
+
+
+def _static_feature_contributions() -> list[FeatureContribution]:
+    """Return stable explanation data when features.parquet is unavailable."""
+    return [
+        FeatureContribution(feature="SPY_return_30d", value=0.018, contribution=0.031),
+        FeatureContribution(feature="TLT_return_30d", value=-0.011, contribution=-0.014),
+        FeatureContribution(feature="QQQ_RSI", value=61.2, contribution=0.019),
+        FeatureContribution(feature="GLD_MACD_signal", value=0.004, contribution=0.012),
+        FeatureContribution(feature="069500_return_30d", value=0.009, contribution=0.008),
+        FeatureContribution(feature="VNQ_RSI", value=47.6, contribution=-0.006),
+        FeatureContribution(feature="EEM_MACD_signal", value=-0.003, contribution=-0.005),
+        FeatureContribution(feature="114260_return_30d", value=0.006, contribution=0.004),
+    ]
+
+
+def _latest_feature_date() -> str | None:
+    """Return the latest feature date if available."""
+    try:
+        features = pd.read_parquet(FEATURES_PATH, columns=[])
+        if features.empty:
+            return None
+        return features.index[-1].strftime("%Y-%m-%d")
+    except (OSError, ValueError, ImportError):
+        return None
+
+
+def _build_backtest_payload() -> tuple[
+    dict[str, float],
+    list[str],
+    list[float],
+    list[float],
+    list[float],
+    list[float],
+    list[float],
+]:
+    """Use returns.parquet and metrics.py when available; otherwise return deterministic fallback."""
+    try:
+        from src.rl.metrics import calculate_all_metrics
+
+        returns = pd.read_parquet(RETURNS_PATH)
+        if returns.empty:
+            raise ValueError("returns.parquet is empty")
+
+        portfolio_returns = returns.mean(axis=1)
+        benchmark_returns = returns["SPY"] if "SPY" in returns.columns else returns.iloc[:, 0]
+        metrics = _finite_metrics(calculate_all_metrics(portfolio_returns, benchmark_returns))
+
+        wf_cum_array = np.exp(portfolio_returns.cumsum())
+        bm_cum_array = np.exp(benchmark_returns.cumsum())
+        running_peak = np.maximum.accumulate(wf_cum_array)
+        drawdown_array = (wf_cum_array - running_peak) / running_peak
+        rewards_array = portfolio_returns.tail(200).cumsum()
+        sharpe_spark = _rolling_sharpe_spark(portfolio_returns)
+
+        return (
+            metrics,
+            [index.strftime("%Y-%m-%d") for index in returns.index],
+            _finite_float_list(wf_cum_array),
+            _finite_float_list(bm_cum_array),
+            _finite_float_list(rewards_array),
+            _finite_float_list(drawdown_array),
+            sharpe_spark,
+        )
+    except (OSError, ValueError, KeyError, ImportError):
+        return _static_backtest_payload()
+
+
+def _static_backtest_payload() -> tuple[
+    dict[str, float],
+    list[str],
+    list[float],
+    list[float],
+    list[float],
+    list[float],
+    list[float],
+]:
+    """Return deterministic backtest data when local returns are unavailable."""
+    dates = pd.date_range("2024-01-01", periods=252, freq="B")
+    portfolio_returns = pd.Series(np.full(len(dates), 0.00035), index=dates)
+    benchmark_returns = pd.Series(np.full(len(dates), 0.0002), index=dates)
+    wf_cum = np.exp(portfolio_returns.cumsum())
+    bm_cum = np.exp(benchmark_returns.cumsum())
+    drawdown = (wf_cum - np.maximum.accumulate(wf_cum)) / np.maximum.accumulate(wf_cum)
+    metrics = {
+        "cumulative_return": 0.092,
+        "cagr": 0.092,
+        "annualized_volatility": 0.0,
+        "var_95": 0.0,
+        "cvar_95": 0.0,
+        "mdd": 0.0,
+        "sharpe_ratio": 0.0,
+        "sortino_ratio": 0.0,
+        "calmar_ratio": 0.0,
+        "alpha": 0.038,
+        "beta": 0.0,
+        "information_ratio": 0.0,
+    }
+    return (
+        metrics,
+        [item.strftime("%Y-%m-%d") for item in dates],
+        _finite_float_list(wf_cum),
+        _finite_float_list(bm_cum),
+        _finite_float_list(portfolio_returns.tail(200).cumsum()),
+        _finite_float_list(drawdown),
+        [0.0] * 50,
+    )
+
+
+def _fallback_anova() -> list[AnovaResult]:
+    """Return the three planned ANOVA fallback summaries."""
+    return [
         AnovaResult(
             name="reward_function_comparison",
             f_statistic=3.12,
@@ -140,37 +428,43 @@ def build_fallback_backtest() -> BacktestResponse:
             post_hoc="p >= 0.05; report effect size interpretation.",
         ),
     ]
-    return BacktestResponse(
-        status="fallback",
-        metrics=metrics,
-        anova=anova,
-        benchmark="SPY",
-        message="Walk-Forward 백테스트 모듈 연결 전 fallback 결과입니다.",
-    )
 
 
-def _risk_adjusted_raw_weights(tickers: list[str], risk_profile: RiskProfile) -> dict[str, float]:
-    """Build simple deterministic tilts by risk profile."""
-    raw_weights = {ticker: 1.0 for ticker in tickers}
-    if risk_profile == "conservative":
-        for ticker in ("TLT", "GLD", "114260"):
-            if ticker in raw_weights:
-                raw_weights[ticker] += 0.5
-    elif risk_profile == "aggressive":
-        for ticker in ("SPY", "QQQ", "IWM", "EEM"):
-            if ticker in raw_weights:
-                raw_weights[ticker] += 0.5
-    return raw_weights
+def _rolling_sharpe_spark(returns: pd.Series) -> list[float]:
+    """Build a compact rolling Sharpe series for dashboard metric sparklines."""
+    rolling_mean = returns.rolling(window=30, min_periods=2).mean()
+    rolling_std = returns.rolling(window=30, min_periods=2).std()
+    sharpe = (rolling_mean / rolling_std.replace(0.0, np.nan)) * np.sqrt(TRADING_DAYS)
+    sharpe = sharpe.replace([np.inf, -np.inf], np.nan).fillna(0.0).tail(50)
+    return _finite_float_list(sharpe)
 
 
-def _profile_return(risk_profile: RiskProfile) -> float:
-    """Expected annual return placeholder by risk profile."""
-    return {"conservative": 0.052, "balanced": 0.084, "aggressive": 0.112}[risk_profile]
+def _finite_metrics(metrics: dict[str, float]) -> dict[str, float]:
+    """Convert NaN/inf metric values to 0.0 for JSON-safe responses."""
+    return {key: _finite_float(value) for key, value in metrics.items()}
 
 
-def _profile_volatility(risk_profile: RiskProfile) -> float:
-    """Expected annual volatility placeholder by risk profile."""
-    return {"conservative": 0.085, "balanced": 0.132, "aggressive": 0.184}[risk_profile]
+def _finite_float_list(values: Any) -> list[float]:
+    """Convert array-like values to finite rounded floats."""
+    return [_finite_float(value) for value in list(values)]
+
+
+def _finite_float(value: Any) -> float:
+    """Return a JSON-safe float."""
+    number = float(value)
+    if not np.isfinite(number):
+        return 0.0
+    return round(number, 6)
+
+
+def _can_load_data_files() -> bool:
+    """Check whether the API can read the local parquet data files."""
+    try:
+        returns = pd.read_parquet(RETURNS_PATH)
+        features = pd.read_parquet(FEATURES_PATH)
+    except (OSError, ValueError, ImportError):
+        return False
+    return not returns.empty and not features.empty
 
 
 def _infer_risk_tags(question: str) -> list[str]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import math
 
 from fastapi.testclient import TestClient
 
+import apps.api.services as api_services
 from apps.api.main import app
 
 client = TestClient(app)
@@ -21,12 +22,11 @@ def test_health_returns_module_status() -> None:
     assert payload["status"] == "ok"
     assert payload["api"]["host"]
     assert payload["api"]["port"] == 8000
-    assert payload["modules"] == {
-        "data": "ready",
-        "rl": "fallback",
-        "rag": "fallback",
-        "shap": "fallback",
-    }
+    assert payload["modules"]["data"] in {"ready", "fallback"}
+    assert payload["modules"]["rl"] == "fallback"
+    assert payload["modules"]["rag"] in {"ready", "fallback"}
+    assert payload["modules"]["shap"] == "fallback"
+    assert payload["modules"]["backtest"] == "fallback"
 
 
 def test_optimize_returns_normalized_weights_for_default_assets() -> None:
@@ -43,6 +43,23 @@ def test_optimize_returns_normalized_weights_for_default_assets() -> None:
     assert payload["risk_profile"] == "balanced"
 
 
+def test_optimize_accepts_dashboard_risk_aversion_and_returns_series() -> None:
+    """POST /optimize should support dashboard payloads and chart-ready returns."""
+    response = client.post("/optimize", json={"risk_aversion": 1.5})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "fallback"
+    assert math.isclose(sum(payload["weights"].values()), 1.0, abs_tol=1e-9)
+
+    returns = payload["returns"]
+    assert set(returns) == {"date", "portfolio", "benchmark"}
+    assert len(returns["date"]) > 0
+    assert len(returns["date"]) == len(returns["portfolio"]) == len(returns["benchmark"])
+    assert all(value > 0 for value in returns["portfolio"])
+    assert all(value > 0 for value in returns["benchmark"])
+
+
 def test_explain_returns_feature_contributions() -> None:
     """POST /explain should provide SHAP-like contribution records."""
     response = client.post("/explain", json={"date": "2024-12-31", "top_k": 5})
@@ -53,6 +70,15 @@ def test_explain_returns_feature_contributions() -> None:
     assert payload["date"] == "2024-12-31"
     assert len(payload["feature_contributions"]) == 5
     assert {"feature", "value", "contribution"} <= set(payload["feature_contributions"][0])
+    assert payload["target_date"] == "2024-12-31"
+    assert len(payload["feature_names"]) == 5
+    assert len(payload["shap_values"]) == 5
+    assert payload["feature_names"] == [
+        item["feature"] for item in payload["feature_contributions"]
+    ]
+    assert payload["shap_values"] == [
+        item["contribution"] for item in payload["feature_contributions"]
+    ]
     assert isinstance(payload["base_value"], float)
     assert isinstance(payload["prediction"], float)
 
@@ -76,6 +102,24 @@ def test_research_returns_report_sources_trace_and_risk_tags() -> None:
     assert payload["question"].startswith("금리 인하")
 
 
+def test_research_falls_back_when_graph_raises(monkeypatch) -> None:
+    """POST /research should keep returning 200 when LangGraph cannot run."""
+
+    def raise_graph_error(question: str) -> dict:
+        raise RuntimeError(f"graph unavailable for {question}")
+
+    monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(api_services, "run_graph", raise_graph_error)
+
+    response = client.post("/research", json={"question": "금리 급등 리스크는?"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "fallback"
+    assert payload["report"]
+    assert payload["risk_tags"] == ["급등락"]
+
+
 def test_backtest_returns_metrics_and_anova_results() -> None:
     """GET /backtest should return 12 metrics and the three ANOVA checks."""
     response = client.get("/backtest")
@@ -84,13 +128,20 @@ def test_backtest_returns_metrics_and_anova_results() -> None:
     payload = response.json()
     assert payload["status"] == "fallback"
     assert len(payload["metrics"]) == 12
-    assert {"cumulative_return", "cagr", "sharpe_ratio", "max_drawdown"} <= set(payload["metrics"])
+    assert {"cumulative_return", "cagr", "sharpe_ratio", "mdd"} <= set(payload["metrics"])
     assert len(payload["anova"]) == 3
     assert {item["name"] for item in payload["anova"]} == {
         "reward_function_comparison",
         "strategy_comparison",
         "market_regime_comparison",
     }
+
+    assert len(payload["dates"]) > 0
+    assert len(payload["dates"]) == len(payload["wf_cum"]) == len(payload["bm_cum"])
+    assert len(payload["dates"]) == len(payload["drawdown"])
+    assert len(payload["rewards"]) > 0
+    assert payload["safeguard"]["active"] is False
+    assert payload["safeguard"]["triggered_at"] is None
 
 
 def test_openapi_schema_contains_sprint2_endpoints() -> None:


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용
FastAPI 0~4단계 계획에 맞춰 현재 디렉토리에 있는 구현만 실제 연동하고, 없는 PPO/SHAP/backtest/ANOVA 모듈은 fallback 응답으로 유지했습니다.

- `/optimize`, `/explain`, `/backtest` 응답을 Streamlit 대시보드가 바로 사용할 수 있는 필드까지 확장했습니다.
- `/research`는 `src.agent.graph.run_graph()`를 우선 호출하되, API 키 누락이나 LangGraph 실행 실패 시 fallback으로 200 응답을 유지합니다.
- `/health`는 parquet 데이터와 환경 설정 기준으로 module readiness를 동적으로 반환합니다.
- `tests/test_api.py`에 dashboard payload/응답, research fallback, backtest chart field 계약 테스트를 추가했습니다.

## 변경된 파일
| 파일 | 변경 내용 |
|------|---------|
| `apps/api/schemas.py` | `risk_aversion`, chart return series, SHAP dashboard fields, backtest dashboard fields 스키마 추가 |
| `apps/api/services.py` | parquet 기반 fallback portfolio/backtest/explain 생성, LangGraph research wrapper, module status helper 추가 |
| `apps/api/routers/health.py` | 동적 module readiness 반환으로 변경 |
| `apps/api/routers/optimize.py` | dashboard `risk_aversion` 요청을 service layer로 전달 |
| `apps/api/routers/research.py` | fallback-only 응답에서 LangGraph 우선 호출 service로 변경 |
| `tests/test_api.py` | 0~4단계 API 계약 및 fallback 안정성 테스트 추가 |

## 테스트 결과
```bash
$ .venv/bin/python -m pytest tests/test_api.py -q
........                                                                 [100%]
8 passed in 0.37s

$ .venv/bin/python -m black --check apps/api tests/test_api.py
All done! ✨ 🍰 ✨
11 files would be left unchanged.
```

추가 확인:
```bash
$ .venv/bin/python -m pytest tests/test_metrics.py -q
.....                                                                    [100%]
5 passed in 0.17s

$ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python .venv/bin/python -m pytest tests/test_graph.py -q
.                                                                        [100%]
1 passed in 1.74s
```

참고: 전체 non-integration suite는 기존 `src/rl/env.py`의 `np.bool_` vs Python `bool` 반환 문제로 `tests/test_env.py` 2개가 실패합니다. 이번 PR 범위인 `apps/api/`와 `tests/test_api.py`는 통과 확인했습니다.

## 체크리스트
- [x] 담당 파일 외 다른 팀원 파일 무단 수정 없음
- [x] `.env` 파일 커밋 안 함
- [x] 새 함수/클래스에 docstring 작성
- [x] 테스트 통과 확인 (`pytest`)
- [x] PR 대상 브랜치가 `dev`인지 확인 (셀프 merge 금지)

## 기타 참고 사항
- 현재 디렉토리에 `src/rl/shap.py`, `src/rl/backtest.py`, `src/rl/anova.py`, 저장된 PPO 모델 파일이 없으므로 해당 기능은 의도적으로 `status="fallback"` 응답을 유지합니다.
- `gh` CLI가 로컬에 없어 GitHub 커넥터로 PR을 생성했습니다.