### PR TITLE
[REFACTOR] 리스크 태그 canonical 네이밍 전면 적용 (_risk suffix)

### DIFF
--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -10,7 +10,7 @@ import requests
 try:
     from src.agent.risk_tags import RL_RISK_TAGS
 except ImportError:
-    RL_RISK_TAGS = ["macro_rate", "equity_market", "geopolitical_fx"]
+    RL_RISK_TAGS = ["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
 _RESEARCH_NODE_LABELS = {
     "planner": "질문 분석",
     "researcher": "문서 검색",

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -428,7 +428,7 @@ def _mock_research(question: str) -> dict:
             "[THINK][grade_documents] 판정: 충분 — analyst 진행\n"
             "[THINK][analyst] 최종 리포트 생성 착수"
         ),
-        "risk_tags": ["equity_market"],
+        "risk_tags": ["equity_market_risk"],
     }
 
 

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -137,7 +137,7 @@ PPO 강화학습 기반 포트폴리오 최적 비중 계산.
   "tickers": ["SPY", "QQQ", "IWM", "EFA", "EEM", "TLT", "GLD", "VNQ", "069500", "114260"],
   "risk_profile": "balanced",
   "risk_aversion": 1.0,
-  "risk_tags": ["equity_market", "macro_rate"]
+  "risk_tags": ["equity_market_risk", "macro_rate_risk"]
 }
 ```
 
@@ -148,7 +148,7 @@ PPO 강화학습 기반 포트폴리오 최적 비중 계산.
 | `risk_aversion` | `float` (> 0) | 아니오 | `null` | 수치형 위험 회피 계수. 설정 시 `risk_profile` 보다 우선 |
 | `risk_tags` | `list[str] \| null` | 아니오 | `null` | `/research/stream` 완료 이벤트에서 받은 RL 연동 리스크 태그. PPO ready 경로에서 `risk_vector`로 변환 |
 
-> **대시보드 호출 예시**: `POST /optimize` `{"risk_aversion": 1.5, "risk_tags": ["equity_market", "macro_rate"]}`
+> **대시보드 호출 예시**: `POST /optimize` `{"risk_aversion": 1.5, "risk_tags": ["equity_market_risk", "macro_rate_risk"]}`
 
 #### 응답 `200 OK`
 
@@ -287,7 +287,7 @@ LangGraph RAG 에이전트를 통한 투자 리서치 리포트 생성.
     "https://..."
   ],
   "reasoning_trace": "[THINK][planner] 질의 분석 시작\n[THINK][researcher] Chroma hit=5건\n...",
-  "risk_tags": ["macro_rate", "equity_market"]
+  "risk_tags": ["macro_rate_risk", "equity_market_risk"]
 }
 ```
 
@@ -298,7 +298,7 @@ LangGraph RAG 에이전트를 통한 투자 리서치 리포트 생성.
 | `report` | `str` | Markdown 형식 투자 분석 리포트 |
 | `sources` | `list[str]` | 참고한 뉴스 URL 목록 (없으면 GitHub 레포 URL) |
 | `reasoning_trace` | `str` | LangGraph 내부 추론 과정 (`[THINK][노드명]` 접두사) |
-| `risk_tags` | `list[str]` | 감지된 리스크 태그 (`"macro_rate"` \| `"equity_market"` \| `"geopolitical_fx"` 중 해당 항목) |
+| `risk_tags` | `list[str]` | 감지된 리스크 태그 (`"macro_rate_risk"` \| `"equity_market_risk"` \| `"geopolitical_fx_risk"` 중 해당 항목) |
 
 #### LangGraph 연동 시그니처 (강유영 제공)
 
@@ -333,7 +333,7 @@ NDJSON 이벤트는 한 줄에 JSON 객체 1개를 반환한다.
 {"type":"start","question":"삼성전자 HBM 전망은?"}
 {"type":"on_chain_start","name":"planner","text":"..."}
 {"type":"on_chain_end","name":"analyst","text":"분석 완료"}
-{"type":"complete","question":"삼성전자 HBM 전망은?","report":"...","sources":["https://..."],"reasoning_trace":"[THINK]...","risk_tags":["equity_market"]}
+{"type":"complete","question":"삼성전자 HBM 전망은?","report":"...","sources":["https://..."],"reasoning_trace":"[THINK]...","risk_tags":["equity_market_risk"]}
 ```
 
 `complete` 이벤트 스키마는 아래 필드를 포함한다.

--- a/docs/labels_and_interfaces.md
+++ b/docs/labels_and_interfaces.md
@@ -96,15 +96,15 @@ date,regime
 
 | 순서 | 태그 | obs 인덱스 | 커버하는 이벤트 유형 |
 |------|------|-----------|-------------------|
-| 0 | `macro_rate` | obs[-3] | 금리 인상·인하, FOMC, CPI, 국채금리 변동, 한국은행 기준금리 |
-| 1 | `equity_market` | obs[-2] | 증시 급락, 경기침체, VIX 급등, 어닝쇼크, KOSPI 급락 |
-| 2 | `geopolitical_fx` | obs[-1] | 전쟁, 관세, 수출 규제, 공급망 충격, 환율 급변 |
+| 0 | `macro_rate_risk` | obs[-3] | 금리 인상·인하, FOMC, CPI, 국채금리 변동, 한국은행 기준금리 |
+| 1 | `equity_market_risk` | obs[-2] | 증시 급락, 경기침체, VIX 급등, 어닝쇼크, KOSPI 급락 |
+| 2 | `geopolitical_fx_risk` | obs[-1] | 전쟁, 관세, 수출 규제, 공급망 충격, 환율 급변 |
 
 **벡터 변환 예시**:
 ```python
 from src.agent.risk_tags import get_risk_vector, extract_rl_risk_tags
 
-tags = extract_rl_risk_tags("Fed 기준금리 0.75%p 인상")   # → ["macro_rate"]
+tags = extract_rl_risk_tags("Fed 기준금리 0.75%p 인상")   # → ["macro_rate_risk"]
 vec  = get_risk_vector("Fed 기준금리 0.75%p 인상")         # → array([1., 0., 0.], dtype=float32)
 #                                                                   macro  equity  geo
 # ※ get_risk_vector는 text를 직접 받음 (tags 리스트 아님)
@@ -130,7 +130,7 @@ vec = np.array(risk_df.loc[pd.Timestamp("2022-06-15"), ["risk_macro","risk_equit
 공통 태그 순서는 항상 아래와 같다.
 
 ```python
-["macro_rate", "equity_market", "geopolitical_fx"]
+["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
 ```
 
 벡터 매핑은 키워드 밀도 스코어 기반(0.0~1.0)이며, `get_risk_vector`는 text를 직접 받는다.
@@ -138,7 +138,7 @@ vec = np.array(risk_df.loc[pd.Timestamp("2022-06-15"), ["risk_macro","risk_equit
 ```python
 from src.agent.risk_tags import get_risk_vector
 vec = get_risk_vector("증시 급락 어닝쇼크 VIX 급등")
-# array([0., 1., 0.], dtype=float32)  ← equity_market 감지
+# array([0., 1., 0.], dtype=float32)  ← equity_market_risk 감지
 ```
 
 장점은 사용자별 서버 상태 저장소, DB, 만료 정책 없이 단순하게 구현할 수 있고, `/optimize` 요청이 self-contained라 API 테스트가 쉽다는 점이다. 한계는 브라우저 새로고침, Streamlit 세션 만료, Streamlit 재시작 시 `risk_tags`가 사라지고, 서버에서 “이 최적화가 어떤 리서치 결과에 근거했는지” 이력을 추적할 수 없다는 점이다. 서버 이력 추적이 필요하면 후속 단계에서 `risk_context_id` 저장소를 추가한다.

--- a/docs/rag_eval_questions.json
+++ b/docs/rag_eval_questions.json
@@ -2,61 +2,61 @@
   {
     "id": "Q01",
     "question": "금리 인상이 ETF 포트폴리오에 미치는 영향은?",
-    "expect_rl_tags": ["macro_rate"]
+    "expect_rl_tags": ["macro_rate_risk"]
   },
   {
     "id": "Q02",
     "question": "한국 금융당국 규제 강화 및 정책 변경 시 투자 리스크는?",
-    "expect_rl_tags": ["geopolitical_fx"]
+    "expect_rl_tags": ["geopolitical_fx_risk"]
   },
   {
     "id": "Q03",
     "question": "코스피 급락·변동성 확대 시 포트폴리오 리스크와 대응 전략은?",
-    "expect_rl_tags": ["equity_market"]
+    "expect_rl_tags": ["equity_market_risk"]
   },
   {
     "id": "Q04",
     "question": "어닝쇼크·실적 부진 관련 최근 증시 리스크는?",
-    "expect_rl_tags": ["equity_market"]
+    "expect_rl_tags": ["equity_market_risk"]
   },
   {
     "id": "Q05",
     "question": "미국 연준 기준금리 결정이 한국 채권 ETF에 미치는 영향은?",
-    "expect_rl_tags": ["macro_rate"]
+    "expect_rl_tags": ["macro_rate_risk"]
   },
   {
     "id": "Q06",
     "question": "원달러 환율 급등 시 포트폴리오 리스크 관리 방법은?",
-    "expect_rl_tags": ["geopolitical_fx"]
+    "expect_rl_tags": ["geopolitical_fx_risk"]
   },
   {
     "id": "Q07",
     "question": "지정학적 리스크(전쟁, 무역분쟁)가 국내 증시에 미치는 영향은?",
-    "expect_rl_tags": ["geopolitical_fx", "equity_market"]
+    "expect_rl_tags": ["geopolitical_fx_risk", "equity_market_risk"]
   },
   {
     "id": "Q08",
     "question": "인플레이션 상승이 자산 배분 전략에 미치는 영향은?",
-    "expect_rl_tags": ["macro_rate"]
+    "expect_rl_tags": ["macro_rate_risk"]
   },
   {
     "id": "Q09",
     "question": "시장 변동성 VIX 지수 급등 시 방어적 포트폴리오 구성 전략은?",
-    "expect_rl_tags": ["equity_market"]
+    "expect_rl_tags": ["equity_market_risk"]
   },
   {
     "id": "Q10",
     "question": "공급망 차질 및 원자재 가격 급등이 ETF 수익률에 미치는 영향은?",
-    "expect_rl_tags": ["geopolitical_fx", "macro_rate"]
+    "expect_rl_tags": ["geopolitical_fx_risk", "macro_rate_risk"]
   },
   {
     "id": "Q11",
     "question": "한국은행 기준금리 인상이 부동산·채권 시장에 미치는 영향은?",
-    "expect_rl_tags": ["macro_rate"]
+    "expect_rl_tags": ["macro_rate_risk"]
   },
   {
     "id": "Q12",
     "question": "글로벌 경기침체 우려가 국내 주식형 ETF에 미치는 리스크는?",
-    "expect_rl_tags": ["equity_market", "macro_rate"]
+    "expect_rl_tags": ["equity_market_risk", "macro_rate_risk"]
   }
 ]

--- a/docs/spec_tag_mapping.md
+++ b/docs/spec_tag_mapping.md
@@ -11,16 +11,16 @@
 
 | 과제 명세 예시 (자연어) | 팀 RL 축 | parquet 컬럼 | obs 순서 |
 |------------------------|----------|-------------|---------|
-| 금리 인상·인하, FOMC, Fed, CPI·PPI, 국채금리, 달러 강세, 한국은행 기준금리, 채권 가격 변동 | **macro_rate** | `macro_rate_risk` | 0 |
-| 증시 급락·폭락, 경기침체 우려, 어닝쇼크, VIX 급등, 패닉셀, KOSPI 급락 | **equity_market** | `equity_market_risk` | 1 |
-| 전쟁·지정학 갈등, 관세·무역 전쟁, 반도체 수출 규제, 공급망 충격, 환율 급변 | **geopolitical_fx** | `geopolitical_fx_risk` | 2 |
+| 금리 인상·인하, FOMC, Fed, CPI·PPI, 국채금리, 달러 강세, 한국은행 기준금리, 채권 가격 변동 | **macro_rate_risk** | `macro_rate_risk` | 0 |
+| 증시 급락·폭락, 경기침체 우려, 어닝쇼크, VIX 급등, 패닉셀, KOSPI 급락 | **equity_market_risk** | `equity_market_risk` | 1 |
+| 전쟁·지정학 갈등, 관세·무역 전쟁, 반도체 수출 규제, 공급망 충격, 환율 급변 | **geopolitical_fx_risk** | `geopolitical_fx_risk` | 2 |
 
 > **구 태그(레거시) 매핑**
 > | 구 태그 | 신 태그 | 비고 |
 > |--------|--------|------|
-> | 규제변경 | `macro_rate` + `geopolitical_fx` (내용에 따라) | 정책·법률 규제 → macro, 수출규제·제재 → geo |
-> | 실적쇼크 | `equity_market` | |
-> | 급등락 | `equity_market` 주도 (+ 원인에 따라 macro/geo 보완) | |
+> | 규제변경 | `macro_rate_risk` + `geopolitical_fx_risk` (내용에 따라) | 정책·법률 규제 → macro, 수출규제·제재 → geo |
+> | 실적쇼크 | `equity_market_risk` | |
+> | 급등락 | `equity_market_risk` 주도 (+ 원인에 따라 macro/geo 보완) | |
 
 ---
 
@@ -68,5 +68,5 @@ obs_dim = (lookback + 3) * n_assets + 3  →  (30+3)*10+3 = 333
 | `macro_rate_risk` | 0.0 \| 0.33 \| 0.66 \| 1.0 |
 | `equity_market_risk` | 0.0 \| 0.33 \| 0.66 \| 1.0 |
 | `geopolitical_fx_risk` | 0.0 \| 0.33 \| 0.66 \| 1.0 |
-| `primary_tag` | `"macro_rate"` \| `"equity_market"` \| `"geopolitical_fx"` \| `"none"` |
+| `primary_tag` | `"macro_rate_risk"` \| `"equity_market_risk"` \| `"geopolitical_fx_risk"` \| `"none"` |
 | `label_method` | `"rule_based"` \| `"manual"` \| `"llm"` |

--- a/scripts/build_risk_parquet.py
+++ b/scripts/build_risk_parquet.py
@@ -45,16 +45,16 @@ DATE_START = "2018-01-01"
 DATE_END   = "2025-12-31"
 
 DECAY_PERIODS: Dict[str, int] = {
-    "macro_rate":      30,
-    "equity_market":   10,
-    "geopolitical_fx": 60,
+    "macro_rate_risk":      30,
+    "equity_market_risk":   10,
+    "geopolitical_fx_risk": 60,
 }
 
 # 입력 컬럼명 (팀원 parquet의 라벨 컬럼)
 SEVERITY_COLS: Dict[str, str] = {
-    "macro_rate":      "macro_rate_risk",
-    "equity_market":   "equity_market_risk",
-    "geopolitical_fx": "geopolitical_fx_risk",
+    "macro_rate_risk":      "macro_rate_risk",
+    "equity_market_risk":   "equity_market_risk",
+    "geopolitical_fx_risk": "geopolitical_fx_risk",
 }
 
 RAW_PATHS: List[Path] = [
@@ -133,9 +133,9 @@ def compute_daily_decay(events: pd.DataFrame) -> pd.DataFrame:
     risk_geo    = np.zeros(n, dtype=np.float64)
 
     arrays = {
-        "macro_rate":      risk_macro,
-        "equity_market":   risk_equity,
-        "geopolitical_fx": risk_geo,
+        "macro_rate_risk":      risk_macro,
+        "equity_market_risk":   risk_equity,
+        "geopolitical_fx_risk": risk_geo,
     }
 
     for _, event in events.iterrows():

--- a/scripts/collect_ecos.py
+++ b/scripts/collect_ecos.py
@@ -64,7 +64,7 @@ SERIES_CONFIG = [
         "item_code":     "0101000",
         "cycle":         "M",
         "name":          "한국은행 기준금리",
-        "tag":           "macro_rate",
+        "tag":           "macro_rate_risk",
         "processor_key": "722Y001",
     },
     {
@@ -72,7 +72,7 @@ SERIES_CONFIG = [
         "item_code":     "0000001",
         "cycle":         "D",
         "name":          "원/달러 환율",
-        "tag":           "geopolitical_fx",
+        "tag":           "geopolitical_fx_risk",
         "processor_key": "036Y001",   # processor 재사용
     },
     {
@@ -81,7 +81,7 @@ SERIES_CONFIG = [
         "item_code":     "0",
         "cycle":         "M",
         "name":          "소비자물가지수 (CPI)",
-        "tag":           "macro_rate",
+        "tag":           "macro_rate_risk",
         "processor_key": "021Y126",   # processor 재사용
     },
     {
@@ -90,7 +90,7 @@ SERIES_CONFIG = [
         "item_code":     "010200000",
         "cycle":         "D",
         "name":          "국고채 3년 수익률",
-        "tag":           "macro_rate",
+        "tag":           "macro_rate_risk",
         "processor_key": "731Y001_bond3y",
     },
     {
@@ -98,7 +98,7 @@ SERIES_CONFIG = [
         "item_code":     "010210000",
         "cycle":         "D",
         "name":          "국고채 10년 수익률",
-        "tag":           "macro_rate",
+        "tag":           "macro_rate_risk",
         "processor_key": "731Y001_bond10y",
     },
     {
@@ -106,7 +106,7 @@ SERIES_CONFIG = [
         "item_code":     "0001000",
         "cycle":         "D",
         "name":          "KOSPI",
-        "tag":           "equity_market",
+        "tag":           "equity_market_risk",
         "processor_key": "802Y001",
     },
 ]
@@ -268,7 +268,7 @@ def process_base_rate(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     "macro_rate_risk":     severity,
                     "equity_market_risk":  round(severity * 0.5, 2),
                     "geopolitical_fx_risk": round(severity * 0.2, 2),
-                    "primary_tag":         "macro_rate",
+                    "primary_tag":         "macro_rate_risk",
                     "reasoning":           f"기준금리 {diff:+.2f}%p 변경",
                     "confidence":          1.0,
                 })
@@ -316,7 +316,7 @@ def process_usdkrw(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "macro_rate_risk":     round(severity * 0.3, 2),
                 "equity_market_risk":  round(severity * 0.3, 2),
                 "geopolitical_fx_risk": severity,
-                "primary_tag":         "geopolitical_fx",
+                "primary_tag":         "geopolitical_fx_risk",
                 "reasoning":           f"원/달러 {change_pct:+.2f}% 급변",
                 "confidence":          1.0,
             })
@@ -362,7 +362,7 @@ def process_cpi(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "macro_rate_risk":     severity,
                 "equity_market_risk":  round(severity * 0.4, 2),
                 "geopolitical_fx_risk": round(severity * 0.2, 2),
-                "primary_tag":         "macro_rate",
+                "primary_tag":         "macro_rate_risk",
                 "reasoning":           f"CPI YoY {yoy:.1f}%",
                 "confidence":          1.0,
             })
@@ -408,7 +408,7 @@ def process_bond_3y(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "macro_rate_risk":      severity,
                 "equity_market_risk":   0.0,
                 "geopolitical_fx_risk": 0.0,
-                "primary_tag":          "macro_rate",
+                "primary_tag":          "macro_rate_risk",
                 "reasoning":            f"국고채 3년 {diff_bp:+.1f}bp",
                 "confidence":           1.0,
             })
@@ -454,7 +454,7 @@ def process_bond_10y(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "macro_rate_risk":      severity,
                 "equity_market_risk":   round(severity * 0.3, 2),
                 "geopolitical_fx_risk": 0.0,
-                "primary_tag":          "macro_rate",
+                "primary_tag":          "macro_rate_risk",
                 "reasoning":            f"국고채 10년 {diff_bp:+.1f}bp",
                 "confidence":           1.0,
             })
@@ -498,7 +498,7 @@ def process_kospi(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "macro_rate_risk":      0.0,
                 "equity_market_risk":   severity,
                 "geopolitical_fx_risk": round(severity * 0.3, 2),
-                "primary_tag":          "equity_market",
+                "primary_tag":          "equity_market_risk",
                 "reasoning":            f"KOSPI {change_pct:+.2f}%",
                 "confidence":           1.0,
             })

--- a/scripts/collect_manual_seed.py
+++ b/scripts/collect_manual_seed.py
@@ -34,7 +34,7 @@ REQUIRED_COLS = [
     "primary_tag", "reasoning", "confidence",
 ]
 VALID_RISK_VALUES = {0.0, 0.33, 0.66, 1.0}
-VALID_TAGS        = {"macro_rate", "equity_market", "geopolitical_fx", "none"}
+VALID_TAGS        = {"macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk", "none"}
 
 # sanity check — 알려진 빅 이벤트
 SANITY_CHECKS = {

--- a/scripts/label_events_llm.py
+++ b/scripts/label_events_llm.py
@@ -63,7 +63,7 @@ MAX_TOKENS  = 200
 
 # 유효 리스크 강도 값
 VALID_RISK_VALUES = {0.0, 0.33, 0.66, 1.0}
-VALID_TAGS = {"macro_rate", "equity_market", "geopolitical_fx", "none"}
+VALID_TAGS = {"macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk", "none"}
 
 # ─────────────────────────────────────────────
 # 프롬프트
@@ -118,7 +118,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 미 연준이 22년 만에 0.75%포인트 금리 인상을 단행했다. 파월 의장은 인플레이션 억제를 위해 추가 인상 가능성도 시사했다.\n"
         "출처: fred",
         '{"macro_rate_risk": 1.0, "equity_market_risk": 0.66, "geopolitical_fx_risk": 0.33, '
-        '"primary_tag": "macro_rate", "reasoning": "자이언트 스텝 금리 인상, 22년 만의 충격 이벤트", "confidence": 1.0}',
+        '"primary_tag": "macro_rate_risk", "reasoning": "자이언트 스텝 금리 인상, 22년 만의 충격 이벤트", "confidence": 1.0}',
     ),
     (
         "제목: 러시아, 우크라이나 침공 개시…전면전 돌입\n"
@@ -126,7 +126,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 러시아군이 우크라이나 전역에서 군사작전을 시작했다. 국제 유가는 배럴당 100달러를 돌파했고 안전자산 선호 심리가 확산되고 있다.\n"
         "출처: gdelt",
         '{"macro_rate_risk": 0.33, "equity_market_risk": 0.66, "geopolitical_fx_risk": 1.0, '
-        '"primary_tag": "geopolitical_fx", "reasoning": "전쟁 발발, 유가 100달러 돌파, 안전자산 선호", "confidence": 1.0}',
+        '"primary_tag": "geopolitical_fx_risk", "reasoning": "전쟁 발발, 유가 100달러 돌파, 안전자산 선호", "confidence": 1.0}',
     ),
     (
         "제목: SVB 파산에 미 증시 폭락…나스닥 -2.05%, KBW은행지수 -7.7%\n"
@@ -134,7 +134,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 실리콘밸리은행(SVB) 파산 우려로 미국 은행주가 폭락했다. 시장 전체로 패닉 매도가 확산되며 VIX는 28을 돌파했다.\n"
         "출처: gdelt",
         '{"macro_rate_risk": 0.66, "equity_market_risk": 1.0, "geopolitical_fx_risk": 0.0, '
-        '"primary_tag": "equity_market", "reasoning": "SVB 파산 패닉, 은행주 폭락, VIX 28 돌파", "confidence": 1.0}',
+        '"primary_tag": "equity_market_risk", "reasoning": "SVB 파산 패닉, 은행주 폭락, VIX 28 돌파", "confidence": 1.0}',
     ),
     (
         "제목: 9월 미국 CPI 3.7%…시장 예상치 부합\n"
@@ -142,7 +142,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 미국 9월 소비자물가지수가 전년 동월 대비 3.7% 상승해 시장 예상치에 부합했다. Fed의 추가 금리 인상 가능성은 낮아진 것으로 분석된다.\n"
         "출처: fred",
         '{"macro_rate_risk": 0.66, "equity_market_risk": 0.33, "geopolitical_fx_risk": 0.0, '
-        '"primary_tag": "macro_rate", "reasoning": "CPI 발표, 예상치 부합으로 충격 제한적", "confidence": 1.0}',
+        '"primary_tag": "macro_rate_risk", "reasoning": "CPI 발표, 예상치 부합으로 충격 제한적", "confidence": 1.0}',
     ),
     (
         "제목: 파월 의장 \"인플레이션 둔화 추세 지속 중\"\n"
@@ -150,7 +150,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 잭슨홀 미팅에서 파월 의장은 인플레이션이 둔화되고 있으나 목표치까지 갈 길이 멀다고 언급했다.\n"
         "출처: gdelt",
         '{"macro_rate_risk": 0.33, "equity_market_risk": 0.0, "geopolitical_fx_risk": 0.0, '
-        '"primary_tag": "macro_rate", "reasoning": "Fed 의장 발언, 단순 톤 코멘트", "confidence": 0.66}',
+        '"primary_tag": "macro_rate_risk", "reasoning": "Fed 의장 발언, 단순 톤 코멘트", "confidence": 0.66}',
     ),
     (
         "제목: 美, 대중 반도체 수출 추가 규제…삼성·SK 우려 확산\n"
@@ -158,7 +158,7 @@ FEW_SHOT_PAIRS: List[Tuple[str, str]] = [
         "본문 요약: 미국이 대중국 반도체 장비 수출 규제를 대폭 강화했다. 삼성전자, SK하이닉스 등 한국 반도체 업계도 영향권에 들었으며 코스피는 1.8% 하락했다.\n"
         "출처: gdelt",
         '{"macro_rate_risk": 0.0, "equity_market_risk": 0.66, "geopolitical_fx_risk": 1.0, '
-        '"primary_tag": "geopolitical_fx", "reasoning": "반도체 수출 규제, 한국 반도체 충격, 코스피 하락", "confidence": 1.0}',
+        '"primary_tag": "geopolitical_fx_risk", "reasoning": "반도체 수출 규제, 한국 반도체 충격, 코스피 하락", "confidence": 1.0}',
     ),
     (
         "제목: 코스피, 외국인 매수에 0.4% 상승 마감\n"
@@ -190,7 +190,7 @@ RISK_TAG_SCHEMA = {
                 "macro_rate_risk":     {"type": "number", "enum": [0.0, 0.33, 0.66, 1.0]},
                 "equity_market_risk":  {"type": "number", "enum": [0.0, 0.33, 0.66, 1.0]},
                 "geopolitical_fx_risk":{"type": "number", "enum": [0.0, 0.33, 0.66, 1.0]},
-                "primary_tag":         {"type": "string", "enum": ["macro_rate", "equity_market", "geopolitical_fx", "none"]},
+                "primary_tag":         {"type": "string", "enum": ["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk", "none"]},
                 "reasoning":           {"type": "string"},
                 "confidence":          {"type": "number", "enum": [0.33, 0.66, 1.0]},
             },

--- a/src/agent/news_collector.py
+++ b/src/agent/news_collector.py
@@ -95,7 +95,7 @@ def infer_risk_label(title: str, summary: str) -> str:
     """
     제목·요약에 리스크 관련 키워드가 있으면 메타데이터용 risk_label 문자열을 만듭니다.
 
-    쉼표로 구분된 RL 3축 라벨(예: 'macro_rate,equity_market'). 해당 없으면 빈 문자열.
+    쉼표로 구분된 RL 3축 라벨(예: 'macro_rate_risk,equity_market_risk'). 해당 없으면 빈 문자열.
 
     Args:
         title: 뉴스 제목.
@@ -112,11 +112,11 @@ def infer_risk_label(title: str, summary: str) -> str:
             found.append(label)
 
     if any(k in text for k in ("금리", "기준금리", "연준", "FOMC", "CPI", "물가", "국채", "빅스텝", "자이언트스텝")):
-        add("macro_rate")
+        add("macro_rate_risk")
     if any(k in text for k in ("급락", "폭락", "어닝쇼크", "실적쇼크", "VIX", "증시", "코스피", "코스닥")):
-        add("equity_market")
+        add("equity_market_risk")
     if any(k in text for k in ("지정학", "전쟁", "제재", "규제", "관세", "환율", "달러", "공급망")):
-        add("geopolitical_fx")
+        add("geopolitical_fx_risk")
 
     return ",".join(found)
 

--- a/src/agent/risk_tags.py
+++ b/src/agent/risk_tags.py
@@ -1,7 +1,7 @@
 """
 금융 뉴스 텍스트에서 리스크 태그를 추출하는 모듈.
 
-RL 관측공간 연동용 3종 태그 (macro_rate / equity_market / geopolitical_fx) 와
+팀 합의 3종 태그 (macro_rate_risk / equity_market_risk / geopolitical_fx_risk) 와
 키워드 밀도 기반 연속 스코어(0.0~1.0) 반환 함수를 포함합니다.
 
 실시간 RAG 파이프라인 전용. 과거 데이터 배치 라벨링은 LLM Batch API 사용
@@ -18,13 +18,13 @@ import numpy as np
 # RL 관측공간 연동 — 3종 태그 (이문정 파트 연동 기준)
 # ─────────────────────────────────────────────
 
-RL_RISK_TAGS: List[str] = ["macro_rate", "equity_market", "geopolitical_fx"]
+RL_RISK_TAGS: List[str] = ["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
 
 # Exponential decay 기간 (일). build_risk_parquet.py와 동일 값 유지.
 DECAY_PERIODS: Dict[str, int] = {
-    "macro_rate":      30,   # 금리·매크로 이벤트: 영향 비교적 장기 지속
-    "equity_market":   10,   # 시장 변동성: 비교적 빠르게 정상화
-    "geopolitical_fx": 60,   # 전쟁·제재: 매우 장기 지속
+    "macro_rate_risk":      30,   # 금리·매크로 이벤트: 영향 비교적 장기 지속
+    "equity_market_risk":   10,   # 시장 변동성: 비교적 빠르게 정상화
+    "geopolitical_fx_risk": 60,   # 전쟁·제재: 매우 장기 지속
 }
 
 # ─────────────────────────────────────────────
@@ -69,9 +69,9 @@ GEO_KEYWORDS: List[str] = [
 ]
 
 _KEYWORD_MAP: Dict[str, List[str]] = {
-    "macro_rate":      MACRO_KEYWORDS,
-    "equity_market":   EQUITY_KEYWORDS,
-    "geopolitical_fx": GEO_KEYWORDS,
+    "macro_rate_risk":      MACRO_KEYWORDS,
+    "equity_market_risk":   EQUITY_KEYWORDS,
+    "geopolitical_fx_risk": GEO_KEYWORDS,
 }
 
 # ─────────────────────────────────────────────
@@ -122,7 +122,7 @@ def get_risk_vector(text: str) -> np.ndarray:
 
     Returns:
         np.ndarray shape=(3,), dtype=float32.
-        순서: [macro_rate, equity_market, geopolitical_fx].
+        순서: [macro_rate_risk, equity_market_risk, geopolitical_fx_risk].
     """
     return np.array(score_risk_vector(text), dtype=np.float32)
 
@@ -140,7 +140,7 @@ def apply_decay(severity: float, days_elapsed: int, tag: str) -> float:
     Args:
         severity: 원본 강도 (0.0~1.0).
         days_elapsed: 이벤트 발생 이후 경과 일수.
-        tag: 태그 이름 ("macro_rate" / "equity_market" / "geopolitical_fx").
+        tag: 태그 이름 ("macro_rate_risk" / "equity_market_risk" / "geopolitical_fx_risk").
 
     Returns:
         decay 적용된 강도 (0.0~1.0).

--- a/src/rl/shap.py
+++ b/src/rl/shap.py
@@ -63,7 +63,7 @@ import numpy as np
 import pandas as pd
 
 # RL 리스크 태그 피처명 (관측공간 마지막 3개, labels_and_interfaces.md 2-2절 참고)
-RISK_FEATURE_NAMES: list[str] = ["risk_macro", "risk_equity", "risk_geo"]
+RISK_FEATURE_NAMES: list[str] = ["risk_macro_rate_risk", "risk_equity_market_risk", "risk_geopolitical_fx_risk"]
 
 DEFAULT_ASSET_NAMES: list[str] = [
     "SPY", "QQQ", "IWM", "EFA", "EEM",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,7 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
         tickers: list[str],
         risk_tags: list[str] | None = None,
     ) -> dict[str, float]:
-        assert risk_tags == ["equity_market"]
+        assert risk_tags == ["equity_market_risk"]
         return {tickers[0]: 0.7, tickers[1]: 0.3}
 
     monkeypatch.setattr(
@@ -83,7 +83,7 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
 
     response = client.post(
         "/optimize",
-        json={"tickers": ["SPY", "QQQ"], "risk_tags": ["equity_market"]},
+        json={"tickers": ["SPY", "QQQ"], "risk_tags": ["equity_market_risk"]},
     )
 
     assert response.status_code == 200
@@ -136,7 +136,7 @@ def test_predict_ppo_weights_passes_risk_vector_to_env(monkeypatch) -> None:
     monkeypatch.setattr(api_services, "_load_ppo_model", lambda: FakeModel())
     monkeypatch.setattr(rl_env, "PortfolioEnv", FakeEnv)
 
-    weights = api_services._predict_ppo_weights(["SPY", "QQQ"], ["equity_market", "geopolitical_fx"])
+    weights = api_services._predict_ppo_weights(["SPY", "QQQ"], ["equity_market_risk", "geopolitical_fx_risk"])
 
     assert weights == {"SPY": 0.8, "QQQ": 0.2}
     assert captured["risk_vector"].tolist() == [0.0, 1.0, 1.0]
@@ -273,7 +273,7 @@ def test_research_falls_back_when_graph_raises(monkeypatch) -> None:
     payload = response.json()
     assert payload["status"] in {"ready", "fallback"}
     assert payload["report"]
-    assert payload["risk_tags"] == ["macro_rate"]
+    assert payload["risk_tags"] == ["macro_rate_risk"]
 
 
 def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> None:
@@ -286,7 +286,7 @@ def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> N
             "response": "LangGraph 분석 완료",
             "sources": ["https://example.com/langgraph"],
             "reasoning_trace": "[THINK][analyst] 완료",
-            "rl_risk_tags": ["equity_market"],
+            "rl_risk_tags": ["equity_market_risk"],
         }
 
     monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
@@ -300,7 +300,7 @@ def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> N
     assert payload["status"] == "ready"
     assert payload["report"] == "LangGraph 분석 완료"
     assert payload["sources"] == ["https://example.com/langgraph"]
-    assert payload["risk_tags"] == ["equity_market"]
+    assert payload["risk_tags"] == ["equity_market_risk"]
     assert calls == ["SPY와 TLT 배분 리스크는?"]
 
 
@@ -318,7 +318,7 @@ def test_research_sync_falls_back_when_graph_times_out(monkeypatch) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "fallback"
-    assert payload["risk_tags"] == ["equity_market"]
+    assert payload["risk_tags"] == ["equity_market_risk"]
     assert isinstance(payload["elapsed_ms"], float)
     assert payload["timed_out"] is True
 
@@ -332,7 +332,7 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
         yield {
             "event": "on_chain_end",
             "name": "analyst",
-            "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market"]}},
+            "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market_risk"]}},
         }
 
     monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
@@ -357,7 +357,7 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
     assert '"type":"on_chain_end"' in lines[2]
     assert '"type":"complete"' in lines[-1]
     assert '"report":"분석 완료"' in lines[-1]
-    assert "equity_market" in lines[-1]
+    assert "equity_market_risk" in lines[-1]
 
 
 def test_research_stream_falls_back_quickly_without_api_key(monkeypatch) -> None:
@@ -377,7 +377,7 @@ def test_research_stream_falls_back_quickly_without_api_key(monkeypatch) -> None
     assert elapsed < 5.0
     assert lines
     assert '"type":"fallback"' in lines[-1]
-    assert "equity_market" in lines[-1]
+    assert "equity_market_risk" in lines[-1]
 
 
 def test_backtest_returns_metrics_and_anova_results() -> None:

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -116,11 +116,11 @@ def test_research_complete_event_extracts_rl_risk_tags() -> None:
         "report": "r",
         "sources": [],
         "reasoning_trace": "",
-        "risk_tags": ["equity_market", "geopolitical_fx", "macro_rate_risk"],
+        "risk_tags": ["equity_market_risk", "geopolitical_fx_risk", "macro_rate_risk"],
     }
 
-    assert extract_risk_tags_from_research_event(event) == ["equity_market", "geopolitical_fx"]
-    assert risk_vector_from_tags(["equity_market", "geopolitical_fx"]) == [0.0, 1.0, 1.0]
+    assert extract_risk_tags_from_research_event(event) == ["equity_market_risk", "geopolitical_fx_risk", "macro_rate_risk"]
+    assert risk_vector_from_tags(["equity_market_risk", "geopolitical_fx_risk"]) == [0.0, 1.0, 1.0]
 
 
 def test_research_result_from_complete_event() -> None:
@@ -131,7 +131,7 @@ def test_research_result_from_complete_event() -> None:
         "report": "최종 리포트",
         "sources": ["https://example.com"],
         "reasoning_trace": "trace",
-        "risk_tags": ["equity_market", "macro_rate_risk"],
+        "risk_tags": ["equity_market_risk", "macro_rate_risk"],
     }
 
     result = research_result_from_event(event)
@@ -142,7 +142,7 @@ def test_research_result_from_complete_event() -> None:
         "report": "최종 리포트",
         "sources": ["https://example.com"],
         "reasoning_trace": "trace",
-        "risk_tags": ["equity_market"],
+        "risk_tags": ["equity_market_risk", "macro_rate_risk"],
     }
 
 
@@ -157,6 +157,6 @@ def test_research_log_formatter_filters_noisy_chat_chunks() -> None:
 
 def test_build_optimize_payload_includes_session_risk_tags() -> None:
     """Dashboard /optimize payload should carry session risk tags."""
-    payload = build_optimize_payload(1.5, ["equity_market", "geopolitical_fx"])
+    payload = build_optimize_payload(1.5, ["equity_market_risk", "geopolitical_fx_risk"])
 
-    assert payload == {"risk_aversion": 1.5, "risk_tags": ["equity_market", "geopolitical_fx"]}
+    assert payload == {"risk_aversion": 1.5, "risk_tags": ["equity_market_risk", "geopolitical_fx_risk"]}

--- a/tests/test_google_collector.py
+++ b/tests/test_google_collector.py
@@ -14,14 +14,14 @@ def test_infer_risk_label_empty():
 
 def test_infer_risk_label_regulation_and_shock():
     s = infer_risk_label("규제 강화", "실적쇼크 우려")
-    assert "geopolitical_fx" in s
-    assert "equity_market" in s
+    assert "geopolitical_fx_risk" in s
+    assert "equity_market_risk" in s
 
 
 def test_infer_risk_label_volatility_and_rate():
     s = infer_risk_label("코스피 급락", "금리인상 부담")
-    assert "equity_market" in s
-    assert "macro_rate" in s
+    assert "equity_market_risk" in s
+    assert "macro_rate_risk" in s
 
 
 def test_fetch_google_news_rss_mock():

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -8,7 +8,7 @@ from src.data.market_close import adjust_date_for_market_close
 def test_macro_rate_detected():
     text = "Fed 자이언트 스텝 금리 인상 달러 강세"
     tags = extract_rl_risk_tags(text)
-    assert "macro_rate" in tags
+    assert "macro_rate_risk" in tags
     macro, _, _ = score_risk_vector(text)
     assert macro > 0
 
@@ -16,7 +16,7 @@ def test_macro_rate_detected():
 def test_equity_market_detected():
     text = "삼성전자 어닝쇼크로 증시 급락 VIX 급등"
     tags = extract_rl_risk_tags(text)
-    assert "equity_market" in tags
+    assert "equity_market_risk" in tags
     _, equity, _ = score_risk_vector(text)
     assert equity > 0
 
@@ -24,7 +24,7 @@ def test_equity_market_detected():
 def test_geopolitical_detected():
     text = "러시아-우크라이나 전쟁 원/달러 환율 급등 공급망 차질"
     tags = extract_rl_risk_tags(text)
-    assert "geopolitical_fx" in tags
+    assert "geopolitical_fx_risk" in tags
     _, _, geo = score_risk_vector(text)
     assert geo > 0
 
@@ -42,7 +42,7 @@ def test_risk_vector_shape_and_dtype():
 
 
 def test_rl_risk_tags_order():
-    assert RL_RISK_TAGS == ["macro_rate", "equity_market", "geopolitical_fx"]
+    assert RL_RISK_TAGS == ["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
 
 
 def test_score_risk_vector_range():

--- a/tests/test_shap.py
+++ b/tests/test_shap.py
@@ -39,9 +39,9 @@ def test_feature_names_risk_tags_at_end():
     """마지막 3개 피처명이 RISK_FEATURE_NAMES와 일치하는지 검증합니다."""
     names = get_feature_names(TICKERS_10, lookback=30)
     assert names[-3:] == RISK_FEATURE_NAMES
-    assert names[-3] == "risk_macro"
-    assert names[-2] == "risk_equity"
-    assert names[-1] == "risk_geo"
+    assert names[-3] == "risk_macro_rate_risk"
+    assert names[-2] == "risk_equity_market_risk"
+    assert names[-1] == "risk_geopolitical_fx_risk"
 
 
 def test_feature_names_returns_window_oldest_first():
@@ -73,7 +73,7 @@ def test_feature_names_concat_order():
     # MACD_signal 블록 시작
     assert names[rsi_end].endswith("_MACD_signal")
     # risk 블록 시작
-    assert names[macd_end] == "risk_macro"
+    assert names[macd_end] == "risk_macro_rate_risk"
 
 
 def test_feature_names_all_tickers_present_in_returns():


### PR DESCRIPTION
## Summary

- 팀 합의 태그명 `macro_rate_risk` / `equity_market_risk` / `geopolitical_fx_risk` 을 코드·문서 전체에 적용
- 기존 `macro_rate` / `equity_market` / `geopolitical_fx` (suffix 없음) 완전 제거

## 변경 파일

| 카테고리 | 파일 |
|---------|------|
| 핵심 정의 | `src/agent/risk_tags.py` — RL_RISK_TAGS, DECAY_PERIODS, _KEYWORD_MAP |
| 수집·분류 | `src/agent/news_collector.py`, `scripts/collect_ecos.py`, `collect_manual_seed.py`, `label_events_llm.py` |
| 빌드 | `scripts/build_risk_parquet.py` — DECAY_PERIODS·SEVERITY_COLS 키 |
| RL/SHAP | `src/rl/shap.py` — RISK_FEATURE_NAMES (`risk_macro_rate_risk` 등) |
| 대시보드 | `apps/dashboard/api_client.py`, `app.py` |
| 테스트 | `test_risk.py`, `test_api.py`, `test_dashboard_api_client.py`, `test_google_collector.py`, `test_shap.py` |
| 문서 | `docs/api_spec.md`, `labels_and_interfaces.md`, `spec_tag_mapping.md`, `rag_eval_questions.json` |

## Test plan

- [x] `pytest tests/ -m "not integration" --ignore=test_collector.py --ignore=test_data.py` → 147 passed
- [x] `grep -r '"macro_rate"' src/ apps/ tests/ scripts/ docs/` → 결과 없음 (구 태그 완전 제거 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)