### PR TITLE
feat: wire risk_signals end-to-end for RL optimize (#61)

### DIFF
--- a/apps/api/routers/optimize.py
+++ b/apps/api/routers/optimize.py
@@ -16,4 +16,5 @@ def optimize_portfolio(request: OptimizeRequest) -> OptimizeResponse:
         risk_profile=request.risk_profile,
         risk_aversion=request.risk_aversion,
         risk_tags=request.risk_tags,
+        risk_signals=request.risk_signals,
     )

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 RiskProfile = Literal["conservative", "balanced", "aggressive"]
 EndpointStatus = Literal["ready", "fallback", "unavailable"]
 BacktestWindow = Literal["w1", "w2", "w3", "final"]
+RiskTag = Literal["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
 
 
 class ApiStatus(BaseModel):
@@ -32,6 +33,7 @@ class OptimizeRequest(BaseModel):
     risk_profile: RiskProfile = "balanced"
     risk_aversion: float | None = Field(default=None, gt=0)
     risk_tags: list[str] | None = None
+    risk_signals: list["RiskSignal"] | None = None
 
 
 class ReturnSeries(BaseModel):
@@ -62,6 +64,13 @@ class ExplainRequest(BaseModel):
 
     date: str | None = None
     top_k: int = Field(default=8, ge=1, le=20)
+
+
+class RiskSignal(BaseModel):
+    """Quantized risk signal used for RL observation inputs."""
+
+    tag: RiskTag
+    severity: float = Field(ge=0.0, le=1.0)
 
 
 class FeatureContribution(BaseModel):
@@ -105,6 +114,7 @@ class ResearchResponse(BaseModel):
     sources: list[str]
     reasoning_trace: str
     risk_tags: list[str]
+    risk_signals: list[RiskSignal] = Field(default_factory=list)
 
 
 class TukeyRow(BaseModel):

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -26,6 +26,13 @@ class HealthResponse(BaseModel):
     modules: dict[str, EndpointStatus]
 
 
+class RiskSignal(BaseModel):
+    """Quantized risk signal used for RL observation inputs."""
+
+    tag: RiskTag
+    severity: float = Field(ge=0.0, le=1.0)
+
+
 class OptimizeRequest(BaseModel):
     """Portfolio optimization request."""
 
@@ -33,7 +40,7 @@ class OptimizeRequest(BaseModel):
     risk_profile: RiskProfile = "balanced"
     risk_aversion: float | None = Field(default=None, gt=0)
     risk_tags: list[str] | None = None
-    risk_signals: list["RiskSignal"] | None = None
+    risk_signals: list[RiskSignal] | None = None
 
 
 class ReturnSeries(BaseModel):
@@ -64,13 +71,6 @@ class ExplainRequest(BaseModel):
 
     date: str | None = None
     top_k: int = Field(default=8, ge=1, le=20)
-
-
-class RiskSignal(BaseModel):
-    """Quantized risk signal used for RL observation inputs."""
-
-    tag: RiskTag
-    severity: float = Field(ge=0.0, le=1.0)
 
 
 class ReasoningEvent(BaseModel):

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -73,12 +73,25 @@ class RiskSignal(BaseModel):
     severity: float = Field(ge=0.0, le=1.0)
 
 
+class ReasoningEvent(BaseModel):
+    """One event-level reasoning trace linked to SHAP output."""
+
+    event_date: str
+    days_elapsed: int
+    tag: str
+    severity: float
+    decayed_score: float
+    reasoning: str
+    source: str
+
+
 class FeatureContribution(BaseModel):
     """One feature contribution for a SHAP-like explanation."""
 
     feature: str
     value: float
     contribution: float
+    reasoning_context: list[ReasoningEvent] = Field(default_factory=list)
 
 
 class ExplainResponse(BaseModel):
@@ -94,6 +107,7 @@ class ExplainResponse(BaseModel):
     feature_contributions: list[FeatureContribution]
     feature_names: list[str]
     shap_values: list[float]
+    reasoning_context: list[ReasoningEvent] = Field(default_factory=list)
     message: str
 
 

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator
 
 import numpy as np
 import pandas as pd
+from pydantic import ValidationError
 
 from apps.api.config import settings
 from apps.api.schemas import (
@@ -158,12 +159,11 @@ def build_portfolio_response(
     start = perf_counter()
     selected_tickers = tickers or DEFAULT_TICKERS
     selected_risk_tags = risk_tags or []
-    selected_risk_signals = risk_signals or _risk_signals_from_tags(selected_risk_tags)
     try:
         weights = _predict_ppo_weights_with_timeout(
             selected_tickers,
             selected_risk_tags,
-            selected_risk_signals,
+            risk_signals,
         )
     except Exception as exc:
         return build_fallback_portfolio(
@@ -575,18 +575,19 @@ def _predict_ppo_weights(
 
     from src.rl.env import PortfolioEnv
 
+    selected_signals = _resolve_risk_signals(risk_tags, risk_signals)
+    risk_vector = _signals_to_vector(selected_signals) if selected_signals else None
+    env_kwargs: dict[str, Any] = {
+        "returns_df": returns,
+        "features_df": features,
+        "lookback": 30,
+        "reward_type": "sharpe",
+    }
+    if risk_vector is not None:
+        env_kwargs["risk_vector"] = risk_vector
+
     model = _load_ppo_model()
-    env = PortfolioEnv(
-        returns_df=returns,
-        features_df=features,
-        lookback=30,
-        reward_type="sharpe",
-    )
-    selected_signals = _normalize_risk_signals(risk_signals) or _risk_signals_from_tags(
-        risk_tags or []
-    )
-    if selected_signals:
-        env.set_risk_vector(_signals_to_vector(selected_signals))
+    env = PortfolioEnv(**env_kwargs)
     obs, _ = env.reset()
     env.current_step = len(env.features_df) - 1
     obs = env._get_observation()
@@ -1192,6 +1193,14 @@ def _risk_signals_from_tags(tags: list[str]) -> list[RiskSignal]:
     return [RiskSignal(tag=tag, severity=1.0) for tag in _normalize_rl_risk_tags(tags)]
 
 
+def _resolve_risk_signals(
+    risk_tags: list[str] | None,
+    risk_signals: Any,
+) -> list[RiskSignal]:
+    """Resolve request risk_signals, falling back to legacy risk_tags only once."""
+    return _normalize_risk_signals(risk_signals) or _risk_signals_from_tags(risk_tags or [])
+
+
 def _normalize_risk_signals(raw_signals: Any) -> list[RiskSignal]:
     """Normalize raw risk signal payload into validated RiskSignal entries."""
     if not isinstance(raw_signals, list):
@@ -1209,7 +1218,7 @@ def _normalize_risk_signals(raw_signals: Any) -> list[RiskSignal]:
             continue
         try:
             normalized.append(RiskSignal(tag=str(tag), severity=float(severity)))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, ValidationError):
             continue
     return normalized
 

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -29,6 +29,7 @@ from apps.api.schemas import (
     InteractionStats,
     OptimizeResponse,
     ResearchResponse,
+    RiskSignal,
     ReturnSeries,
     RiskProfile,
     SafeguardState,
@@ -134,13 +135,19 @@ def build_portfolio_response(
     risk_profile: RiskProfile = "balanced",
     risk_aversion: float | None = None,
     risk_tags: list[str] | None = None,
+    risk_signals: list[RiskSignal] | None = None,
 ) -> OptimizeResponse:
     """Return PPO portfolio weights when available, otherwise fallback weights."""
     start = perf_counter()
     selected_tickers = tickers or DEFAULT_TICKERS
-    selected_risk_tags = risk_tags if risk_tags is not None else _default_rl_risk_tags()
+    selected_risk_tags = risk_tags or []
+    selected_risk_signals = risk_signals or _risk_signals_from_tags(selected_risk_tags)
     try:
-        weights = _predict_ppo_weights_with_timeout(selected_tickers, selected_risk_tags)
+        weights = _predict_ppo_weights_with_timeout(
+            selected_tickers,
+            selected_risk_tags,
+            selected_risk_signals,
+        )
     except Exception as exc:
         return build_fallback_portfolio(
             selected_tickers,
@@ -321,6 +328,7 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
             "sources": response.sources,
             "reasoning_trace": response.reasoning_trace,
             "risk_tags": response.risk_tags,
+            "risk_signals": [signal.model_dump() for signal in response.risk_signals],
         }
     )
 
@@ -333,7 +341,14 @@ def _state_from_graph_event(event: dict[str, Any]) -> dict[str, Any] | None:
     output = data.get("output")
     if not isinstance(output, dict):
         return None
-    useful_keys = {"response", "sources", "reasoning_trace", "risk_tags", "rl_risk_tags"}
+    useful_keys = {
+        "response",
+        "sources",
+        "reasoning_trace",
+        "risk_tags",
+        "rl_risk_tags",
+        "risk_signals",
+    }
     if not any(key in output for key in useful_keys):
         return None
     return {str(key): value for key, value in output.items() if key in useful_keys}
@@ -413,6 +428,9 @@ def _research_response_from_state(question: str, state: dict[str, Any]) -> Resea
     reasoning_trace = state.get("reasoning_trace") or "\n".join(str(item) for item in messages)
     raw_risk_tags = state.get("rl_risk_tags") or state.get("risk_tags") or []
     risk_tags = _normalize_rl_risk_tags(raw_risk_tags) or _infer_risk_tags(question)
+    risk_signals = _normalize_risk_signals(state.get("risk_signals")) or _risk_signals_from_tags(
+        risk_tags
+    )
     sources = [str(source) for source in state.get("sources", []) if source]
 
     return ResearchResponse(
@@ -422,6 +440,7 @@ def _research_response_from_state(question: str, state: dict[str, Any]) -> Resea
         sources=sources or ["https://github.com/AI-Robo-Advisor/rl-rag-roboadvisor"],
         reasoning_trace=reasoning_trace,
         risk_tags=risk_tags,
+        risk_signals=risk_signals,
     )
 
 
@@ -451,6 +470,7 @@ def build_fallback_research(
             ]
         ),
         risk_tags=risk_tags,
+        risk_signals=_risk_signals_from_tags(risk_tags),
     )
 
 
@@ -513,6 +533,7 @@ def build_module_statuses() -> dict[str, str]:
 def _predict_ppo_weights(
     tickers: list[str],
     risk_tags: list[str] | None = None,
+    risk_signals: list[RiskSignal] | None = None,
 ) -> dict[str, float]:
     """Run the trained PPO policy once and return selected asset weights."""
     returns = _load_returns()
@@ -521,14 +542,7 @@ def _predict_ppo_weights(
     if missing:
         raise ValueError(f"Unknown tickers for PPO model: {missing}")
 
-    from src.agent.risk_tags import RL_RISK_TAGS
     from src.rl.env import PortfolioEnv
-
-    risk_tags_set = set(risk_tags or [])
-    risk_vector = np.array(
-        [1.0 if tag in risk_tags_set else 0.0 for tag in RL_RISK_TAGS],
-        dtype=np.float32,
-    )
 
     model = _load_ppo_model()
     env = PortfolioEnv(
@@ -536,8 +550,12 @@ def _predict_ppo_weights(
         features_df=features,
         lookback=30,
         reward_type="sharpe",
-        risk_vector=risk_vector,
     )
+    selected_signals = _normalize_risk_signals(risk_signals) or _risk_signals_from_tags(
+        risk_tags or []
+    )
+    if selected_signals:
+        env.set_risk_vector(_signals_to_vector(selected_signals))
     obs, _ = env.reset()
     env.current_step = len(env.features_df) - 1
     obs = env._get_observation()
@@ -550,9 +568,10 @@ def _predict_ppo_weights(
 def _predict_ppo_weights_with_timeout(
     tickers: list[str],
     risk_tags: list[str] | None = None,
+    risk_signals: list[RiskSignal] | None = None,
 ) -> dict[str, float]:
     """Run PPO inference with a request-time budget."""
-    future = _PPO_EXECUTOR.submit(_predict_ppo_weights, tickers, risk_tags or [])
+    future = _PPO_EXECUTOR.submit(_predict_ppo_weights, tickers, risk_tags or [], risk_signals)
     try:
         return future.result(timeout=PPO_TIMEOUT_SECONDS)
     except TimeoutError:
@@ -1135,6 +1154,44 @@ def _normalize_rl_risk_tags(tags: Any) -> list[str]:
     except Exception:
         return []
     return [str(tag) for tag in tags or [] if str(tag) in allowed]
+
+
+def _risk_signals_from_tags(tags: list[str]) -> list[RiskSignal]:
+    """Convert risk tags into default-severity signals for backward compatibility."""
+    return [RiskSignal(tag=tag, severity=1.0) for tag in _normalize_rl_risk_tags(tags)]
+
+
+def _normalize_risk_signals(raw_signals: Any) -> list[RiskSignal]:
+    """Normalize raw risk signal payload into validated RiskSignal entries."""
+    if not isinstance(raw_signals, list):
+        return []
+    normalized: list[RiskSignal] = []
+    for item in raw_signals:
+        if isinstance(item, RiskSignal):
+            normalized.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        tag = item.get("tag")
+        severity = item.get("severity")
+        if tag is None or severity is None:
+            continue
+        try:
+            normalized.append(RiskSignal(tag=str(tag), severity=float(severity)))
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def _signals_to_vector(signals: list[RiskSignal]) -> np.ndarray:
+    """Build RL observation risk vector from RiskSignal entries."""
+    from src.agent.risk_tags import RL_RISK_TAGS, apply_decay
+
+    severity_by_tag = {signal.tag: signal.severity for signal in signals}
+    return np.array(
+        [apply_decay(float(severity_by_tag.get(tag, 0.0)), 0, tag) for tag in RL_RISK_TAGS],
+        dtype=np.float32,
+    )
 
 
 def _to_ndjson(payload: dict[str, Any]) -> str:

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -28,6 +28,7 @@ from apps.api.schemas import (
     FeatureContribution,
     InteractionStats,
     OptimizeResponse,
+    ReasoningEvent,
     ResearchResponse,
     RiskSignal,
     ReturnSeries,
@@ -42,11 +43,13 @@ os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
 RETURNS_PATH = Path("data/processed/returns.parquet")
 FEATURES_PATH = Path("data/processed/features.parquet")
 SHAP_ARTIFACT_PATH = Path("data/processed/shap_explanations.json")
+UNIFIED_EVENTS_PATH = Path("data/processed/unified_events.parquet")
 PPO_MODEL_PATH = Path("models/ppo_sharpe_final_risk.zip")
 TRADING_DAYS = 252
 PPO_TIMEOUT_SECONDS = 4.75
 SHAP_TIMEOUT_SECONDS = 4.75
 RESEARCH_TIMEOUT_SECONDS = 4.5
+REASONING_WINDOW_DAYS = 3
 _PPO_EXECUTOR = ThreadPoolExecutor(max_workers=1)
 _SHAP_EXECUTOR = ThreadPoolExecutor(max_workers=1)
 _RESEARCH_EXECUTOR = ThreadPoolExecutor(max_workers=1)
@@ -76,6 +79,20 @@ DEFAULT_TICKERS: list[str] = [
     "069500",
     "114260",
 ]
+
+_TAG_TO_SEVERITY_COL: dict[str, str] = {
+    "macro_rate_risk": "macro_rate_risk",
+    "equity_market_risk": "equity_market_risk",
+    "geopolitical_fx_risk": "geopolitical_fx_risk",
+}
+_RISK_FEATURE_TO_TAG: dict[str, str] = {
+    "risk_macro_rate_risk": "macro_rate_risk",
+    "risk_macro": "macro_rate_risk",
+    "risk_equity_market_risk": "equity_market_risk",
+    "risk_equity": "equity_market_risk",
+    "risk_geopolitical_fx_risk": "geopolitical_fx_risk",
+    "risk_geo": "geopolitical_fx_risk",
+}
 
 
 def _elapsed_ms(start: float) -> float:
@@ -206,6 +223,7 @@ def build_fallback_explanation(
     selected = features[:top_k]
     prediction = 0.05 + sum(item.contribution for item in selected)
     target_date = date or _latest_feature_date()
+    reasoning_context = _build_reasoning_events(target_date) if target_date else []
     return ExplainResponse(
         status="fallback",
         elapsed_ms=elapsed_ms,
@@ -214,9 +232,10 @@ def build_fallback_explanation(
         target_date=target_date,
         base_value=0.05,
         prediction=round(prediction, 6),
-        feature_contributions=selected,
+        feature_contributions=_attach_feature_reasoning_context(selected, target_date),
         feature_names=[item.feature for item in selected],
         shap_values=[item.contribution for item in selected],
+        reasoning_context=reasoning_context,
         message="SHAP 모듈 연결 전 feature contribution fallback입니다.",
     )
 
@@ -226,19 +245,31 @@ def build_explanation_response(date: str | None, top_k: int) -> ExplainResponse:
     start = perf_counter()
     try:
         result = _shap_from_artifact(date, top_k) or _compute_ready_shap_with_timeout(date, top_k)
+        target_date = result.get("target_date")
+        target_date_text = str(target_date) if target_date is not None else None
+        feature_contributions = [
+            FeatureContribution(**item) for item in result.get("feature_contributions", [])
+        ]
+        top_reasoning_context = _build_reasoning_events(
+            target_date_text,
+            raw_context=result.get("reasoning_context"),
+        )
         return ExplainResponse(
             status="ready",
             elapsed_ms=_elapsed_ms(start),
             timed_out=False,
             date=result.get("date"),
-            target_date=result.get("target_date"),
+            target_date=target_date,
             base_value=result.get("base_value", 0.0),
             prediction=result.get("prediction", 0.0),
-            feature_contributions=[
-                FeatureContribution(**item) for item in result.get("feature_contributions", [])
-            ],
+            feature_contributions=_attach_feature_reasoning_context(
+                feature_contributions,
+                target_date_text,
+                raw_context=result.get("reasoning_context"),
+            ),
             feature_names=list(result.get("feature_names", [])),
             shap_values=list(result.get("shap_values", [])),
+            reasoning_context=top_reasoning_context,
             message=result.get("message", "PPO SHAP 분석 완료."),
         )
     except Exception as exc:
@@ -1192,6 +1223,149 @@ def _signals_to_vector(signals: list[RiskSignal]) -> np.ndarray:
         [apply_decay(float(severity_by_tag.get(tag, 0.0)), 0, tag) for tag in RL_RISK_TAGS],
         dtype=np.float32,
     )
+
+
+@lru_cache(maxsize=1)
+def _load_unified_events() -> pd.DataFrame:
+    """Load unified event-level reasoning rows from parquet."""
+    if not UNIFIED_EVENTS_PATH.exists():
+        return pd.DataFrame()
+    try:
+        events = pd.read_parquet(UNIFIED_EVENTS_PATH)
+    except (OSError, ValueError, ImportError):
+        return pd.DataFrame()
+    if events.empty or "date" not in events.columns:
+        return pd.DataFrame()
+    loaded = events.copy()
+    loaded["date"] = pd.to_datetime(loaded["date"], errors="coerce")
+    return loaded.dropna(subset=["date"])
+
+
+def _normalize_reasoning_event(
+    raw_event: dict[str, Any],
+    target_date: pd.Timestamp,
+) -> ReasoningEvent | None:
+    """Convert SHAP/unified raw event payload into ReasoningEvent schema."""
+    from src.agent.risk_tags import apply_decay
+
+    event_date_raw = raw_event.get("event_date") or raw_event.get("date")
+    if event_date_raw is None:
+        return None
+    event_ts = pd.to_datetime(event_date_raw, errors="coerce")
+    if pd.isna(event_ts):
+        return None
+
+    tag_raw = raw_event.get("tag") or raw_event.get("primary_tag")
+    tag = str(tag_raw).strip() if tag_raw is not None else ""
+    if tag not in _TAG_TO_SEVERITY_COL:
+        return None
+
+    severity_raw = raw_event.get("severity")
+    if severity_raw is None:
+        severity_raw = raw_event.get(_TAG_TO_SEVERITY_COL[tag], 0.0)
+    try:
+        severity = float(severity_raw)
+    except (TypeError, ValueError):
+        severity = 0.0
+    severity = min(max(severity, 0.0), 1.0)
+
+    days_elapsed = max(int((target_date.normalize() - event_ts.normalize()).days), 0)
+    reasoning = str(raw_event.get("reasoning") or "").strip()
+    source = str(raw_event.get("source") or "")
+
+    return ReasoningEvent(
+        event_date=event_ts.strftime("%Y-%m-%d"),
+        days_elapsed=days_elapsed,
+        tag=tag,
+        severity=round(severity, 6),
+        decayed_score=float(apply_decay(severity, days_elapsed, tag)),
+        reasoning=reasoning,
+        source=source,
+    )
+
+
+def _build_reasoning_events(
+    target_date: str | None,
+    *,
+    tag_filter: str | None = None,
+    window_days: int = REASONING_WINDOW_DAYS,
+    raw_context: Any = None,
+) -> list[ReasoningEvent]:
+    """Build normalized reasoning events from SHAP output or unified events parquet."""
+    if not target_date:
+        return []
+    target_ts = pd.to_datetime(target_date, errors="coerce")
+    if pd.isna(target_ts):
+        return []
+
+    raw_events: list[dict[str, Any]] = []
+    if isinstance(raw_context, list):
+        raw_events = [item for item in raw_context if isinstance(item, dict)]
+    else:
+        events = _load_unified_events()
+        if events.empty:
+            return []
+        lower = target_ts - pd.Timedelta(days=window_days)
+        upper = target_ts + pd.Timedelta(days=window_days)
+        windowed = events[(events["date"] >= lower) & (events["date"] <= upper)].copy()
+        if windowed.empty:
+            return []
+        raw_events = [
+            {
+                "event_date": row["date"],
+                "source": row.get("source"),
+                "tag": row.get("primary_tag"),
+                "severity": row.get(row.get("primary_tag", ""), row.get("severity", 0.0)),
+                "reasoning": row.get("reasoning"),
+            }
+            for _, row in windowed.iterrows()
+        ]
+
+    normalized = [
+        event
+        for item in raw_events
+        for event in [_normalize_reasoning_event(item, target_ts)]
+        if event is not None
+    ]
+    if tag_filter:
+        normalized = [item for item in normalized if item.tag == tag_filter]
+    normalized.sort(key=lambda item: (item.event_date, item.tag))
+    return normalized
+
+
+def _risk_tag_from_feature(feature_name: str) -> str | None:
+    """Resolve RL risk tag from a SHAP feature name."""
+    lowered = feature_name.strip().lower()
+    for key, tag in _RISK_FEATURE_TO_TAG.items():
+        if key in lowered:
+            return tag
+    return None
+
+
+def _attach_feature_reasoning_context(
+    contributions: list[FeatureContribution],
+    target_date: str | None,
+    *,
+    raw_context: Any = None,
+) -> list[FeatureContribution]:
+    """Attach reasoning context to risk_* feature contributions only."""
+    attached: list[FeatureContribution] = []
+    for contribution in contributions:
+        tag = _risk_tag_from_feature(contribution.feature)
+        context = (
+            _build_reasoning_events(target_date, tag_filter=tag, raw_context=raw_context)
+            if tag and target_date
+            else []
+        )
+        attached.append(
+            FeatureContribution(
+                feature=contribution.feature,
+                value=contribution.value,
+                contribution=contribution.contribution,
+                reasoning_context=context,
+            )
+        )
+    return attached
 
 
 def _to_ndjson(payload: dict[str, Any]) -> str:

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -26,28 +26,31 @@ def _mock_warning_message(endpoint: str, exc: Exception) -> str:
 
 def extract_risk_tags_from_research_event(event: dict[str, Any]) -> list[str]:
     """Return RL risk tags from a research stream complete/fallback event."""
-    event_type = event.get("type")
-    if event_type == "complete":
-        raw_tags = event.get("risk_tags", [])
-    elif event_type == "fallback":
-        data = event.get("data") or {}
-        raw_tags = data.get("risk_tags", []) if isinstance(data, dict) else []
-    else:
-        raw_tags = []
-    return [str(tag) for tag in raw_tags if str(tag) in RL_RISK_TAGS]
+    return extract_risk_context_from_research_event(event)[0]
 
 
 def extract_risk_signals_from_research_event(event: dict[str, Any]) -> list[dict[str, Any]]:
     """Return validated risk_signals from research stream events."""
+    return extract_risk_context_from_research_event(event)[1]
+
+
+def extract_risk_context_from_research_event(
+    event: dict[str, Any],
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Return validated risk_tags and risk_signals from a final research event."""
     event_type = event.get("type")
     if event_type == "complete":
+        raw_tags = event.get("risk_tags", [])
         raw_signals = event.get("risk_signals", [])
     elif event_type == "fallback":
         data = event.get("data") or {}
+        raw_tags = data.get("risk_tags", []) if isinstance(data, dict) else []
         raw_signals = data.get("risk_signals", []) if isinstance(data, dict) else []
     else:
+        raw_tags = []
         raw_signals = []
 
+    tags = [str(tag) for tag in raw_tags if str(tag) in RL_RISK_TAGS]
     normalized: list[dict[str, Any]] = []
     for item in raw_signals:
         if not isinstance(item, dict):
@@ -59,35 +62,39 @@ def extract_risk_signals_from_research_event(event: dict[str, Any]) -> list[dict
             severity = float(item.get("severity", 0.0))
         except (TypeError, ValueError):
             continue
-        normalized.append({"tag": tag, "severity": max(0.0, min(1.0, severity))})
-    return normalized
+        if not 0.0 <= severity <= 1.0:
+            continue
+        normalized.append({"tag": tag, "severity": severity})
+    return tags, normalized
 
 
 def research_result_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
     """Normalize a research stream final event into dashboard session data."""
     event_type = event.get("type")
     if event_type == "complete":
+        tags, signals = extract_risk_context_from_research_event(event)
         return {
             "status": "ready",
             "question": str(event.get("question", "")),
             "report": str(event.get("report", "")),
             "sources": [str(source) for source in event.get("sources", []) if source],
             "reasoning_trace": str(event.get("reasoning_trace", "")),
-            "risk_tags": extract_risk_tags_from_research_event(event),
-            "risk_signals": extract_risk_signals_from_research_event(event),
+            "risk_tags": tags,
+            "risk_signals": signals,
         }
     if event_type == "fallback":
         data = event.get("data") or {}
         if not isinstance(data, dict):
             return None
+        tags, signals = extract_risk_context_from_research_event(event)
         return {
             "status": str(data.get("status", "fallback")),
             "question": str(data.get("question", "")),
             "report": str(data.get("report", "")),
             "sources": [str(source) for source in data.get("sources", []) if source],
             "reasoning_trace": str(data.get("reasoning_trace", "")),
-            "risk_tags": extract_risk_tags_from_research_event(event),
-            "risk_signals": extract_risk_signals_from_research_event(event),
+            "risk_tags": tags,
+            "risk_signals": signals,
         }
     return None
 

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -37,6 +37,32 @@ def extract_risk_tags_from_research_event(event: dict[str, Any]) -> list[str]:
     return [str(tag) for tag in raw_tags if str(tag) in RL_RISK_TAGS]
 
 
+def extract_risk_signals_from_research_event(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return validated risk_signals from research stream events."""
+    event_type = event.get("type")
+    if event_type == "complete":
+        raw_signals = event.get("risk_signals", [])
+    elif event_type == "fallback":
+        data = event.get("data") or {}
+        raw_signals = data.get("risk_signals", []) if isinstance(data, dict) else []
+    else:
+        raw_signals = []
+
+    normalized: list[dict[str, Any]] = []
+    for item in raw_signals:
+        if not isinstance(item, dict):
+            continue
+        tag = str(item.get("tag") or "")
+        if tag not in RL_RISK_TAGS:
+            continue
+        try:
+            severity = float(item.get("severity", 0.0))
+        except (TypeError, ValueError):
+            continue
+        normalized.append({"tag": tag, "severity": max(0.0, min(1.0, severity))})
+    return normalized
+
+
 def research_result_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
     """Normalize a research stream final event into dashboard session data."""
     event_type = event.get("type")
@@ -48,6 +74,7 @@ def research_result_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
             "sources": [str(source) for source in event.get("sources", []) if source],
             "reasoning_trace": str(event.get("reasoning_trace", "")),
             "risk_tags": extract_risk_tags_from_research_event(event),
+            "risk_signals": extract_risk_signals_from_research_event(event),
         }
     if event_type == "fallback":
         data = event.get("data") or {}
@@ -60,6 +87,7 @@ def research_result_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
             "sources": [str(source) for source in data.get("sources", []) if source],
             "reasoning_trace": str(data.get("reasoning_trace", "")),
             "risk_tags": extract_risk_tags_from_research_event(event),
+            "risk_signals": extract_risk_signals_from_research_event(event),
         }
     return None
 
@@ -100,9 +128,14 @@ def risk_vector_from_tags(risk_tags: list[str] | None) -> list[float]:
 def build_optimize_payload(
     risk_aversion: float,
     risk_tags: list[str] | None = None,
+    risk_signals: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the /optimize request body sent by the dashboard."""
-    return {"risk_aversion": risk_aversion, "risk_tags": list(risk_tags or [])}
+    return {
+        "risk_aversion": risk_aversion,
+        "risk_tags": list(risk_tags or []),
+        "risk_signals": list(risk_signals or []),
+    }
 
 
 def get_json(

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -23,6 +23,7 @@ try:
     from apps.dashboard.api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
+        extract_risk_signals_from_research_event,
         extract_risk_tags_from_research_event,
         format_research_log_event,
         get_json,
@@ -36,6 +37,7 @@ except ModuleNotFoundError:
     from api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
+        extract_risk_signals_from_research_event,
         extract_risk_tags_from_research_event,
         format_research_log_event,
         get_json,
@@ -108,8 +110,10 @@ def _format_research_event(event: dict[str, Any]) -> str:
 def _remember_research_risk_tags(event: dict[str, Any]) -> None:
     """Store stream risk tags in Streamlit session state for /optimize."""
     tags = extract_risk_tags_from_research_event(event)
+    signals = extract_risk_signals_from_research_event(event)
     if event.get("type") in {"complete", "fallback"}:
         st.session_state["risk_tags"] = tags
+        st.session_state["risk_signals"] = signals
         st.session_state["risk_tags_updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         result = research_result_from_event(event)
         if result:
@@ -429,6 +433,7 @@ def _mock_research(question: str) -> dict:
             "[THINK][analyst] 최종 리포트 생성 착수"
         ),
         "risk_tags": ["equity_market_risk"],
+        "risk_signals": [{"tag": "equity_market_risk", "severity": 1.0}],
     }
 
 
@@ -486,6 +491,7 @@ def portfolio_page() -> None:
 
     st.title("포트폴리오 현황")
     current_risk_tags = st.session_state.get("risk_tags", [])
+    current_risk_signals = st.session_state.get("risk_signals", [])
     latest_research = st.session_state.get("research_result", {})
     latest_question = latest_research.get("question")
     latest_updated_at = st.session_state.get("risk_tags_updated_at")
@@ -502,7 +508,11 @@ def portfolio_page() -> None:
 
     if st.button("최적화 실행", key="btn_optimize"):
         with st.spinner("POST /optimize 호출 중…"):
-            payload = build_optimize_payload(risk_aversion, current_risk_tags)
+            payload = build_optimize_payload(
+                risk_aversion,
+                current_risk_tags,
+                current_risk_signals,
+            )
             data = _post("/optimize", payload) or _mock_optimize(risk_aversion)
     else:
         data = _mock_optimize(risk_aversion)

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -23,8 +23,7 @@ try:
     from apps.dashboard.api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
-        extract_risk_signals_from_research_event,
-        extract_risk_tags_from_research_event,
+        extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
         post_json,
@@ -37,8 +36,7 @@ except ModuleNotFoundError:
     from api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
-        extract_risk_signals_from_research_event,
-        extract_risk_tags_from_research_event,
+        extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
         post_json,
@@ -109,8 +107,7 @@ def _format_research_event(event: dict[str, Any]) -> str:
 
 def _remember_research_risk_tags(event: dict[str, Any]) -> None:
     """Store stream risk tags in Streamlit session state for /optimize."""
-    tags = extract_risk_tags_from_research_event(event)
-    signals = extract_risk_signals_from_research_event(event)
+    tags, signals = extract_risk_context_from_research_event(event)
     if event.get("type") in {"complete", "fallback"}:
         st.session_state["risk_tags"] = tags
         st.session_state["risk_signals"] = signals

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -137,7 +137,11 @@ PPO 강화학습 기반 포트폴리오 최적 비중 계산.
   "tickers": ["SPY", "QQQ", "IWM", "EFA", "EEM", "TLT", "GLD", "VNQ", "069500", "114260"],
   "risk_profile": "balanced",
   "risk_aversion": 1.0,
-  "risk_tags": ["equity_market_risk", "macro_rate_risk"]
+  "risk_tags": ["equity_market_risk", "macro_rate_risk"],
+  "risk_signals": [
+    {"tag": "equity_market_risk", "severity": 0.66},
+    {"tag": "macro_rate_risk", "severity": 1.0}
+  ]
 }
 ```
 
@@ -146,9 +150,10 @@ PPO 강화학습 기반 포트폴리오 최적 비중 계산.
 | `tickers` | `list[str]` | 아니오 | 10개 전체 자산 | 최적화할 자산 티커 목록 (1개 이상) |
 | `risk_profile` | `"conservative" \| "balanced" \| "aggressive"` | 아니오 | `"balanced"` | 위험 성향 프리셋 |
 | `risk_aversion` | `float` (> 0) | 아니오 | `null` | 수치형 위험 회피 계수. 설정 시 `risk_profile` 보다 우선 |
-| `risk_tags` | `list[str] \| null` | 아니오 | `null` | `/research/stream` 완료 이벤트에서 받은 RL 연동 리스크 태그. PPO ready 경로에서 `risk_vector`로 변환 |
+| `risk_tags` | `list[str] \| null` | 아니오 | `null` | (호환용) RL 연동 태그. `risk_signals`가 없을 때 severity=1.0으로 승격 |
+| `risk_signals` | `list[RiskSignal] \| null` | 아니오 | `null` | 정량 리스크 신호. PPO ready 경로에서 `apply_decay(severity, 0, tag)` 후 `risk_vector`로 변환 |
 
-> **대시보드 호출 예시**: `POST /optimize` `{"risk_aversion": 1.5, "risk_tags": ["equity_market_risk", "macro_rate_risk"]}`
+> **대시보드 호출 예시**: `POST /optimize` `{"risk_aversion": 1.5, "risk_signals": [{"tag":"equity_market_risk","severity":0.66}]}`
 
 #### 응답 `200 OK`
 
@@ -287,7 +292,11 @@ LangGraph RAG 에이전트를 통한 투자 리서치 리포트 생성.
     "https://..."
   ],
   "reasoning_trace": "[THINK][planner] 질의 분석 시작\n[THINK][researcher] Chroma hit=5건\n...",
-  "risk_tags": ["macro_rate_risk", "equity_market_risk"]
+  "risk_tags": ["macro_rate_risk", "equity_market_risk"],
+  "risk_signals": [
+    {"tag": "macro_rate_risk", "severity": 1.0},
+    {"tag": "equity_market_risk", "severity": 0.66}
+  ]
 }
 ```
 
@@ -299,6 +308,7 @@ LangGraph RAG 에이전트를 통한 투자 리서치 리포트 생성.
 | `sources` | `list[str]` | 참고한 뉴스 URL 목록 (없으면 GitHub 레포 URL) |
 | `reasoning_trace` | `str` | LangGraph 내부 추론 과정 (`[THINK][노드명]` 접두사) |
 | `risk_tags` | `list[str]` | 감지된 리스크 태그 (`"macro_rate_risk"` \| `"equity_market_risk"` \| `"geopolitical_fx_risk"` 중 해당 항목) |
+| `risk_signals` | `list[RiskSignal]` | 감지된 정량 리스크 신호 (`tag`, `severity`) |
 
 #### LangGraph 연동 시그니처 (강유영 제공)
 
@@ -311,6 +321,7 @@ state = run_graph("삼성전자 최근 투자 리스크 분석해줘")
 #   state["sources"]          → list[str]  참고 URL
 #   state["reasoning_trace"]  → str  추론 과정
 #   state["rl_risk_tags"]     → list[str]  리스크 태그
+#   state["risk_signals"]     → list[dict] 정량 리스크 신호 ({tag, severity})
 #   state["messages"]         → list  LangGraph 메시지 (reasoning_trace fallback)
 ```
 
@@ -333,7 +344,7 @@ NDJSON 이벤트는 한 줄에 JSON 객체 1개를 반환한다.
 {"type":"start","question":"삼성전자 HBM 전망은?"}
 {"type":"on_chain_start","name":"planner","text":"..."}
 {"type":"on_chain_end","name":"analyst","text":"분석 완료"}
-{"type":"complete","question":"삼성전자 HBM 전망은?","report":"...","sources":["https://..."],"reasoning_trace":"[THINK]...","risk_tags":["equity_market_risk"]}
+{"type":"complete","question":"삼성전자 HBM 전망은?","report":"...","sources":["https://..."],"reasoning_trace":"[THINK]...","risk_tags":["equity_market_risk"],"risk_signals":[{"tag":"equity_market_risk","severity":0.66}]}
 ```
 
 `complete` 이벤트 스키마는 아래 필드를 포함한다.
@@ -346,8 +357,9 @@ NDJSON 이벤트는 한 줄에 JSON 객체 1개를 반환한다.
 | `sources` | `list[str]` | 참고 URL 목록 |
 | `reasoning_trace` | `str` | 추론 로그 |
 | `risk_tags` | `list[str]` | RL 연동 태그 (`macro_rate_risk`, `equity_market_risk`, `geopolitical_fx_risk`) |
+| `risk_signals` | `list[RiskSignal]` | RL 정량 리스크 신호 (`tag`, `severity`) |
 
-`risk_tags`는 API 서버에 영속 저장하지 않는다. 대시보드는 `complete.risk_tags`를 `st.session_state["risk_tags"]`에 저장하고, 다음 `POST /optimize` 요청에 명시적으로 포함해야 한다.
+`risk_tags`/`risk_signals`는 API 서버에 영속 저장하지 않는다. 대시보드는 `complete` 이벤트의 두 필드를 세션에 저장하고, 다음 `POST /optimize` 요청에 명시적으로 포함해야 한다.
 
 `OPENAI_API_KEY`가 없거나 LangGraph 실행 중 오류가 나면 연결을 오래 유지하지 않고 fallback 이벤트를 반환한다.
 
@@ -355,7 +367,7 @@ NDJSON 이벤트는 한 줄에 JSON 객체 1개를 반환한다.
 {"type":"fallback","name":"research","data":{"status":"fallback","question":"..."}}
 ```
 
-5초 ready 응답 및 TTFB 중심 성능 최적화는 이번 단계의 성공 기준이 아니다. 현재 단계는 `research → risk_tags → Streamlit session → /optimize → get_risk_vector() → PortfolioEnv` 파이프라인 연결을 우선 완료하고, 성능 목표는 후속 최적화 단계에서 재검토한다.
+5초 ready 응답 및 TTFB 중심 성능 최적화는 이번 단계의 성공 기준이 아니다. 현재 단계는 `research → (risk_tags,risk_signals) → Streamlit session → /optimize → apply_decay() → PortfolioEnv` 파이프라인 연결을 우선 완료하고, 성능 목표는 후속 최적화 단계에서 재검토한다.
 
 ---
 
@@ -572,6 +584,11 @@ class OptimizeRequest(BaseModel):
     risk_profile: RiskProfile = "balanced"
     risk_aversion: float | None = Field(default=None, gt=0)
     risk_tags: list[str] | None = None
+    risk_signals: list[RiskSignal] | None = None
+
+class RiskSignal(BaseModel):
+    tag: Literal["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]
+    severity: float  # 0.0 ~ 1.0
 
 class TukeyRow(BaseModel):
     group1:    str

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -151,9 +151,11 @@ PPO 강화학습 기반 포트폴리오 최적 비중 계산.
 | `risk_profile` | `"conservative" \| "balanced" \| "aggressive"` | 아니오 | `"balanced"` | 위험 성향 프리셋 |
 | `risk_aversion` | `float` (> 0) | 아니오 | `null` | 수치형 위험 회피 계수. 설정 시 `risk_profile` 보다 우선 |
 | `risk_tags` | `list[str] \| null` | 아니오 | `null` | (호환용) RL 연동 태그. `risk_signals`가 없을 때 severity=1.0으로 승격 |
-| `risk_signals` | `list[RiskSignal] \| null` | 아니오 | `null` | 정량 리스크 신호. PPO ready 경로에서 `apply_decay(severity, 0, tag)` 후 `risk_vector`로 변환 |
+| `risk_signals` | `list[RiskSignal] \| null` | 아니오 | `null` | 정량 리스크 신호. PPO ready 경로에서 `apply_decay(severity, 0, tag)` 후 `risk_vector`로 변환. `severity` 범위 밖 값은 거부 |
 
 > **대시보드 호출 예시**: `POST /optimize` `{"risk_aversion": 1.5, "risk_signals": [{"tag":"equity_market_risk","severity":0.66}]}`
+
+`risk_signals`와 `risk_tags`가 모두 비어 있으면 API는 요청별 고정 risk_vector를 주입하지 않고 `PortfolioEnv` 기본 동작을 사용한다. 이 경우 `risk_vectors_daily.parquet`가 있으면 최신 거래일 기준 날짜별 리스크 벡터가 자동 로드된다.
 
 #### 응답 `200 OK`
 

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -229,12 +229,23 @@ SHAP 기반 피처 기여도 설명. PPO 모델이 특정 날짜에 내린 결�
   "base_value": 0.05,
   "prediction": 0.063,
   "feature_contributions": [
-    {"feature": "SPY_return", "value": 0.018, "contribution": 0.031},
-    {"feature": "QQQ_RSI",   "value": 61.2,  "contribution": 0.019},
+    {"feature": "SPY_return", "value": 0.018, "contribution": 0.031, "reasoning_context": []},
+    {"feature": "QQQ_RSI",   "value": 61.2,  "contribution": 0.019, "reasoning_context": []},
     "..."
   ],
   "feature_names": ["SPY_return", "QQQ_RSI", "..."],
   "shap_values":   [0.031, 0.019, "..."],
+  "reasoning_context": [
+    {
+      "event_date": "2024-06-13",
+      "days_elapsed": 1,
+      "tag": "equity_market_risk",
+      "severity": 0.66,
+      "decayed_score": 0.5972,
+      "reasoning": "VIX spike to 28.1",
+      "source": "fred"
+    }
+  ],
   "message": "SHAP 모듈 연결 전 feature contribution fallback입니다."
 }
 ```
@@ -249,7 +260,29 @@ SHAP 기반 피처 기여도 설명. PPO 모델이 특정 날짜에 내린 결�
 | `feature_contributions` | `list[FeatureContribution]` | 피처별 기여도 (top_k 개, \|SHAP\| 내림차순) |
 | `feature_names` | `list[str]` | 피처명 배열 (feature_contributions와 순서 동일) |
 | `shap_values` | `list[float]` | SHAP 값 배열 (feature_contributions와 순서 동일) |
+| `reasoning_context` | `list[ReasoningEvent]` | SHAP 해석과 연결된 이벤트 근거 컨텍스트 |
 | `message` | `str` | 상태 설명 메시지 |
+
+`FeatureContribution` 하위 스키마는 다음 필드를 포함한다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `feature` | `str` | 피처 이름 |
+| `value` | `float` | 대상 날짜 관측값 |
+| `contribution` | `float` | SHAP 기여도 |
+| `reasoning_context` | `list[ReasoningEvent]` | `risk_*` 피처에 매핑된 이벤트 근거 (비리스크 피처는 `[]`) |
+
+`ReasoningEvent` 스키마는 다음과 같다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `event_date` | `str` (`YYYY-MM-DD`) | 근거 이벤트 날짜 |
+| `days_elapsed` | `int` | `target_date - event_date` (일) |
+| `tag` | `str` | 리스크 태그 (`macro_rate_risk` \| `equity_market_risk` \| `geopolitical_fx_risk`) |
+| `severity` | `float` | 원본 이벤트 강도 (0~1) |
+| `decayed_score` | `float` | `apply_decay(severity, days_elapsed, tag)` 결과 |
+| `reasoning` | `str` | 이벤트 근거 텍스트 |
+| `source` | `str` | 이벤트 출처 (`gdelt`/`fred`/`ecos`/`manual_seed` 등) |
 
 #### Sprint 3 통합 목표
 

--- a/docs/labels_and_interfaces.md
+++ b/docs/labels_and_interfaces.md
@@ -134,7 +134,7 @@ vec = np.array(risk_df.loc[pd.Timestamp("2022-06-15"), ["risk_macro","risk_equit
   → st.session_state["risk_tags"], st.session_state["risk_signals"]
   → /optimize request.(risk_tags, risk_signals)
   → apply_decay(severity, days_elapsed=0, tag)  # risk_signals 우선
-  → PortfolioEnv.set_risk_vector(...)
+  → PortfolioEnv(risk_vector=...)
 ```
 
 공통 태그 순서는 항상 아래와 같다.

--- a/docs/labels_and_interfaces.md
+++ b/docs/labels_and_interfaces.md
@@ -130,11 +130,11 @@ vec = np.array(risk_df.loc[pd.Timestamp("2022-06-15"), ["risk_macro","risk_equit
 이번 통합 단계의 리스크 전달 흐름은 서버 저장소 없이 Streamlit 세션을 사용한다.
 
 ```text
-/research/stream complete.risk_tags
-  → st.session_state["risk_tags"]
-  → /optimize request.risk_tags
-  → get_risk_vector(risk_tags)
-  → PortfolioEnv(risk_vector=...)
+/research/stream complete.(risk_tags, risk_signals)
+  → st.session_state["risk_tags"], st.session_state["risk_signals"]
+  → /optimize request.(risk_tags, risk_signals)
+  → apply_decay(severity, days_elapsed=0, tag)  # risk_signals 우선
+  → PortfolioEnv.set_risk_vector(...)
 ```
 
 공통 태그 순서는 항상 아래와 같다.
@@ -150,6 +150,9 @@ from src.agent.risk_tags import get_risk_vector
 vec = get_risk_vector("증시 급락 어닝쇼크 VIX 급등")
 # array([0., 1., 0.], dtype=float32)  ← equity_market_risk 감지
 ```
+
+`risk_signals`가 누락된 호출(직접 API 호출, 세션 손실 등)에서는 `PortfolioEnv`가
+`risk_vectors_daily.parquet`를 자동 로드해 최신 거래일 float 값을 사용한다.
 
 장점은 사용자별 서버 상태 저장소, DB, 만료 정책 없이 단순하게 구현할 수 있고, `/optimize` 요청이 self-contained라 API 테스트가 쉽다는 점이다. 한계는 브라우저 새로고침, Streamlit 세션 만료, Streamlit 재시작 시 `risk_tags`가 사라지고, 서버에서 “이 최적화가 어떤 리서치 결과에 근거했는지” 이력을 추적할 수 없다는 점이다. 서버 이력 추적이 필요하면 후속 단계에서 `risk_context_id` 저장소를 추가한다.
 

--- a/docs/risk_signals_handoff.md
+++ b/docs/risk_signals_handoff.md
@@ -1,0 +1,56 @@
+# risk_signals handoff (Agent -> API -> RL)
+
+## 목적
+
+`/research`에서 생성한 정량 위험 신호를 `/optimize`로 전달해 RL 관측 벡터에 반영한다.
+
+## 공통 계약
+
+- 필드명: `risk_signals`
+- 타입: `list[dict]`
+- 원소 스키마:
+  - `tag`: `"macro_rate_risk" | "equity_market_risk" | "geopolitical_fx_risk"`
+  - `severity`: `float` (`0.0 ~ 1.0`)
+
+예시:
+
+```json
+[
+  {"tag": "macro_rate_risk", "severity": 1.0},
+  {"tag": "equity_market_risk", "severity": 0.66}
+]
+```
+
+## Agent 구현 지점
+
+- 파일: `src/agent/nodes.py`
+- 노드: `analyst_node`
+- 입력: 검색 문서 본문 결합 텍스트
+- 계산: `score_risk_vector(all_text)` -> `(macro, equity, geo)`
+- 출력:
+  - `rl_risk_tags` (기존 유지)
+  - `risk_signals` (신규)
+
+## API 처리
+
+- 파일: `apps/api/services.py`
+- `/research`:
+  - `state["risk_signals"]`가 있으면 그대로 정규화해 응답
+  - 없으면 `risk_tags`를 `severity=1.0`으로 승격해 fallback
+- `/optimize`:
+  - `risk_signals` 우선
+  - 없으면 legacy `risk_tags` 승격
+  - 둘 다 없으면 `PortfolioEnv` 기본 동작(파케 자동 로드)
+
+## RL 벡터 변환
+
+- 함수: `_signals_to_vector(signals)`
+- 변환:
+  - 고정 순서: `["macro_rate_risk", "equity_market_risk", "geopolitical_fx_risk"]`
+  - `apply_decay(severity, 0, tag)` 사용
+- 결과 dtype: `np.float32`
+
+## Dashboard 전달
+
+- `complete`/`fallback` 이벤트에서 `risk_signals`를 세션에 저장
+- `/optimize` 요청 payload에 `risk_signals` 포함

--- a/docs/risk_signals_handoff.md
+++ b/docs/risk_signals_handoff.md
@@ -35,12 +35,13 @@
 
 - 파일: `apps/api/services.py`
 - `/research`:
-  - `state["risk_signals"]`가 있으면 그대로 정규화해 응답
+  - `state["risk_signals"]`가 있으면 유효한 `tag`와 `0.0 <= severity <= 1.0` 행만 정규화해 응답
   - 없으면 `risk_tags`를 `severity=1.0`으로 승격해 fallback
 - `/optimize`:
   - `risk_signals` 우선
   - 없으면 legacy `risk_tags` 승격
   - 둘 다 없으면 `PortfolioEnv` 기본 동작(파케 자동 로드)
+  - 신호가 있으면 `PortfolioEnv` 생성자에 `risk_vector`를 직접 넘겨 불필요한 파케 자동 로드를 피함
 
 ## RL 벡터 변환
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -101,6 +101,7 @@ def run_graph(query: str) -> AgentState:
         "response": "",
         "sources": [],
         "reasoning_trace": "",
+        "risk_signals": [],
     }
     return graph.invoke(initial_state)
 
@@ -136,6 +137,7 @@ if __name__ == "__main__":
         "response": "",
         "sources": [],
         "reasoning_trace": "",
+        "risk_signals": [],
     }
 
     think_accum: List[str] = []

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -18,7 +18,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from apps.api.config import settings
-from src.agent.risk_tags import extract_risk_tags, extract_rl_risk_tags
+from src.agent.risk_tags import RL_RISK_TAGS, extract_risk_tags, extract_rl_risk_tags, score_risk_vector
 from src.agent.vectorstore import collection_document_count, query_documents
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ class AgentState(TypedDict):
     sources: List[str]
     reasoning_trace: str
     search_query: NotRequired[str]
+    risk_signals: NotRequired[List[Dict[str, float | str]]]
 
 
 def _think_log(node: str, detail: str) -> str:
@@ -352,6 +353,12 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
     # RL 관측공간 연동용 3종 태그
     all_text = " ".join(d.get("content", "") for d in documents)
     rl_risk_tags: List[str] = extract_rl_risk_tags(all_text) if all_text else []
+    macro, equity, geo = score_risk_vector(all_text)
+    risk_signals = [
+        {"tag": tag, "severity": float(severity)}
+        for tag, severity in zip(RL_RISK_TAGS, [macro, equity, geo])
+        if float(severity) > 0
+    ]
 
     msg = _think_log("analyst", "최종 리포트 생성 착수")
     risk_summary = ", ".join(general_risk_tags) if general_risk_tags else "없음"
@@ -398,5 +405,6 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
         "sources": sources,
         "reasoning_trace": reasoning_trace,
         "rl_risk_tags": rl_risk_tags,
+        "risk_signals": risk_signals,
         "messages": [msg, tail],
     }

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -354,10 +354,15 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
     all_text = " ".join(d.get("content", "") for d in documents)
     rl_risk_tags: List[str] = extract_rl_risk_tags(all_text) if all_text else []
     macro, equity, geo = score_risk_vector(all_text)
+    risk_score_by_tag = {
+        "macro_rate_risk": macro,
+        "equity_market_risk": equity,
+        "geopolitical_fx_risk": geo,
+    }
     risk_signals = [
-        {"tag": tag, "severity": float(severity)}
-        for tag, severity in zip(RL_RISK_TAGS, [macro, equity, geo])
-        if float(severity) > 0
+        {"tag": tag, "severity": float(risk_score_by_tag.get(tag, 0.0))}
+        for tag in RL_RISK_TAGS
+        if float(risk_score_by_tag.get(tag, 0.0)) > 0
     ]
 
     msg = _think_log("analyst", "최종 리포트 생성 착수")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -221,10 +221,15 @@ def test_explain_returns_feature_contributions() -> None:
     assert payload["status"] in {"ready", "fallback"}
     assert payload["date"] == "2024-12-31"
     assert len(payload["feature_contributions"]) == 5
-    assert {"feature", "value", "contribution"} <= set(payload["feature_contributions"][0])
+    assert {"feature", "value", "contribution", "reasoning_context"} <= set(
+        payload["feature_contributions"][0]
+    )
     assert payload["target_date"] <= "2024-12-31"
     assert len(payload["feature_names"]) == 5
     assert len(payload["shap_values"]) == 5
+    assert "reasoning_context" in payload
+    assert isinstance(payload["reasoning_context"], list)
+    assert isinstance(payload["feature_contributions"][0]["reasoning_context"], list)
     assert payload["feature_names"] == [
         item["feature"] for item in payload["feature_contributions"]
     ]
@@ -306,6 +311,86 @@ def test_explain_prefers_precomputed_shap_artifact(monkeypatch, tmp_path) -> Non
     assert payload["feature_names"] == ["SPY_RSI"]
     assert "artifact" in payload["message"]
     api_services._load_shap_artifact.cache_clear()
+
+
+def test_explain_attaches_reasoning_context_for_risk_features_only(monkeypatch) -> None:
+    """Risk SHAP features should receive per-feature reasoning_context only."""
+
+    def fake_compute_ready_shap(date: str | None, top_k: int) -> dict:
+        return {
+            "status": "ready",
+            "date": date,
+            "target_date": "2024-12-30",
+            "base_value": 0.1,
+            "prediction": 0.17,
+            "feature_contributions": [
+                {"feature": "risk_equity_market_risk", "value": 1.0, "contribution": 0.05},
+                {"feature": "SPY_RSI", "value": 60.0, "contribution": 0.02},
+            ],
+            "feature_names": ["risk_equity_market_risk", "SPY_RSI"],
+            "shap_values": [0.05, 0.02],
+            "reasoning_context": [
+                {
+                    "date": "2024-12-29",
+                    "source": "fred",
+                    "primary_tag": "equity_market_risk",
+                    "reasoning": "VIX spike to 32.0",
+                }
+            ],
+            "message": f"PPO SHAP 분석 완료 top_k={top_k}",
+        }
+
+    monkeypatch.setattr(
+        api_services, "_compute_ready_shap_with_timeout", fake_compute_ready_shap, raising=False
+    )
+
+    response = client.post("/explain", json={"date": "2024-12-31", "top_k": 2})
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["status"] == "ready"
+    assert len(payload["reasoning_context"]) == 1
+    assert payload["reasoning_context"][0]["tag"] == "equity_market_risk"
+    assert payload["reasoning_context"][0]["source"] == "fred"
+
+    risk_feature = payload["feature_contributions"][0]
+    normal_feature = payload["feature_contributions"][1]
+    assert risk_feature["feature"] == "risk_equity_market_risk"
+    assert len(risk_feature["reasoning_context"]) == 1
+    assert risk_feature["reasoning_context"][0]["tag"] == "equity_market_risk"
+    assert normal_feature["feature"] == "SPY_RSI"
+    assert normal_feature["reasoning_context"] == []
+
+
+def test_build_reasoning_events_returns_reasoning_event_schema() -> None:
+    """Reasoning mapper should normalize SHAP raw events into API schema."""
+    events = api_services._build_reasoning_events(
+        "2024-12-31",
+        raw_context=[
+            {
+                "date": "2024-12-30",
+                "source": "manual_seed",
+                "primary_tag": "macro_rate_risk",
+                "reasoning": "Fed rate change +0.25%p",
+            }
+        ],
+    )
+
+    assert len(events) == 1
+    event = events[0].model_dump()
+    assert {
+        "event_date",
+        "days_elapsed",
+        "tag",
+        "severity",
+        "decayed_score",
+        "reasoning",
+        "source",
+    } <= set(event)
+    assert event["event_date"] == "2024-12-30"
+    assert event["days_elapsed"] == 1
+    assert event["tag"] == "macro_rate_risk"
+    assert event["source"] == "manual_seed"
 
 
 def test_research_returns_report_sources_trace_and_risk_tags() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,7 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
         risk_signals: list | None = None,
     ) -> dict[str, float]:
         assert risk_tags == ["equity_market_risk"]
-        assert risk_signals is not None
+        assert risk_signals is None
         return {tickers[0]: 0.7, tickers[1]: 0.3}
 
     monkeypatch.setattr(
@@ -96,7 +96,7 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
 
 
 def test_predict_ppo_weights_sets_risk_vector_from_signals(monkeypatch) -> None:
-    """PPO inference should set env risk_vector using risk_signals."""
+    """PPO inference should pass request risk_vector during env construction."""
     captured: dict[str, object] = {}
     dates = pd.date_range("2024-01-01", periods=40, freq="B")
     returns = pd.DataFrame({"SPY": [0.001] * 40, "QQQ": [0.002] * 40}, index=dates)
@@ -121,7 +121,6 @@ def test_predict_ppo_weights_sets_risk_vector_from_signals(monkeypatch) -> None:
             captured["init_kwargs"] = kwargs
             self.features_df = features
             self.asset_names = ["SPY", "QQQ"]
-            self._risk_vector = None
 
         def reset(self):
             return [0.0], {}
@@ -133,8 +132,7 @@ def test_predict_ppo_weights_sets_risk_vector_from_signals(monkeypatch) -> None:
             return action
 
         def set_risk_vector(self, risk_vector):
-            self._risk_vector = risk_vector
-            captured["risk_vector"] = risk_vector
+            captured["set_called"] = True
 
     import src.rl.env as rl_env
 
@@ -153,10 +151,11 @@ def test_predict_ppo_weights_sets_risk_vector_from_signals(monkeypatch) -> None:
     )
 
     assert weights == {"SPY": 0.8, "QQQ": 0.2}
-    assert "risk_vector" not in captured["init_kwargs"]
-    assert captured["risk_vector"][0] == 0.0
-    assert math.isclose(float(captured["risk_vector"][1]), 0.66, rel_tol=0, abs_tol=1e-6)
-    assert captured["risk_vector"][2] == 1.0
+    risk_vector = captured["init_kwargs"]["risk_vector"]
+    assert risk_vector[0] == 0.0
+    assert math.isclose(float(risk_vector[1]), 0.66, rel_tol=0, abs_tol=1e-6)
+    assert risk_vector[2] == 1.0
+    assert "set_called" not in captured
 
 
 def test_predict_ppo_weights_uses_env_default_when_no_signals(monkeypatch) -> None:
@@ -209,6 +208,22 @@ def test_predict_ppo_weights_uses_env_default_when_no_signals(monkeypatch) -> No
     assert weights == {"SPY": 0.8, "QQQ": 0.2}
     assert "risk_vector" not in captured["init_kwargs"]
     assert "set_called" not in captured
+
+
+def test_normalize_risk_signals_rejects_invalid_rows() -> None:
+    """Risk signal normalization should skip malformed, unknown, or out-of-range rows."""
+    signals = api_services._normalize_risk_signals(
+        [
+            {"tag": "equity_market_risk", "severity": 0.66},
+            {"tag": "unknown", "severity": 1.0},
+            {"tag": "macro_rate_risk", "severity": 1.0001},
+            {"tag": "geopolitical_fx_risk", "severity": "bad"},
+        ]
+    )
+
+    assert [signal.model_dump() for signal in signals] == [
+        {"tag": "equity_market_risk", "severity": 0.66}
+    ]
 
 
 def test_explain_returns_feature_contributions() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,8 +73,10 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
     def fake_predict_ppo_weights(
         tickers: list[str],
         risk_tags: list[str] | None = None,
+        risk_signals: list | None = None,
     ) -> dict[str, float]:
         assert risk_tags == ["equity_market_risk"]
+        assert risk_signals is not None
         return {tickers[0]: 0.7, tickers[1]: 0.3}
 
     monkeypatch.setattr(
@@ -93,8 +95,8 @@ def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:
     assert "PPO" in payload["message"]
 
 
-def test_predict_ppo_weights_passes_risk_vector_to_env(monkeypatch) -> None:
-    """PPO inference should convert risk_tags into PortfolioEnv risk_vector."""
+def test_predict_ppo_weights_sets_risk_vector_from_signals(monkeypatch) -> None:
+    """PPO inference should set env risk_vector using risk_signals."""
     captured: dict[str, object] = {}
     dates = pd.date_range("2024-01-01", periods=40, freq="B")
     returns = pd.DataFrame({"SPY": [0.001] * 40, "QQQ": [0.002] * 40}, index=dates)
@@ -116,7 +118,71 @@ def test_predict_ppo_weights_passes_risk_vector_to_env(monkeypatch) -> None:
 
     class FakeEnv:
         def __init__(self, **kwargs):
-            captured["risk_vector"] = kwargs["risk_vector"]
+            captured["init_kwargs"] = kwargs
+            self.features_df = features
+            self.asset_names = ["SPY", "QQQ"]
+            self._risk_vector = None
+
+        def reset(self):
+            return [0.0], {}
+
+        def _get_observation(self):
+            return [0.0]
+
+        def _normalize_action(self, action):
+            return action
+
+        def set_risk_vector(self, risk_vector):
+            self._risk_vector = risk_vector
+            captured["risk_vector"] = risk_vector
+
+    import src.rl.env as rl_env
+
+    monkeypatch.setattr(api_services, "_load_returns", lambda: returns)
+    monkeypatch.setattr(api_services, "_load_features", lambda: features)
+    monkeypatch.setattr(api_services, "_load_ppo_model", lambda: FakeModel())
+    monkeypatch.setattr(rl_env, "PortfolioEnv", FakeEnv)
+
+    weights = api_services._predict_ppo_weights(
+        ["SPY", "QQQ"],
+        ["equity_market_risk", "geopolitical_fx_risk"],
+        [
+            {"tag": "equity_market_risk", "severity": 0.66},
+            {"tag": "geopolitical_fx_risk", "severity": 1.0},
+        ],
+    )
+
+    assert weights == {"SPY": 0.8, "QQQ": 0.2}
+    assert "risk_vector" not in captured["init_kwargs"]
+    assert captured["risk_vector"][0] == 0.0
+    assert math.isclose(float(captured["risk_vector"][1]), 0.66, rel_tol=0, abs_tol=1e-6)
+    assert captured["risk_vector"][2] == 1.0
+
+
+def test_predict_ppo_weights_uses_env_default_when_no_signals(monkeypatch) -> None:
+    """PPO inference should rely on env defaults when no signals are supplied."""
+    captured: dict[str, object] = {}
+    dates = pd.date_range("2024-01-01", periods=40, freq="B")
+    returns = pd.DataFrame({"SPY": [0.001] * 40, "QQQ": [0.002] * 40}, index=dates)
+    features = pd.DataFrame(
+        {
+            "SPY_return": [0.001] * 40,
+            "QQQ_return": [0.002] * 40,
+            "SPY_RSI": [50.0] * 40,
+            "QQQ_RSI": [55.0] * 40,
+            "SPY_MACD_signal": [0.0] * 40,
+            "QQQ_MACD_signal": [0.0] * 40,
+        },
+        index=dates,
+    )
+
+    class FakeModel:
+        def predict(self, obs, deterministic: bool = True):
+            return [0.8, 0.2], None
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
             self.features_df = features
             self.asset_names = ["SPY", "QQQ"]
 
@@ -129,6 +195,9 @@ def test_predict_ppo_weights_passes_risk_vector_to_env(monkeypatch) -> None:
         def _normalize_action(self, action):
             return action
 
+        def set_risk_vector(self, risk_vector):
+            captured["set_called"] = True
+
     import src.rl.env as rl_env
 
     monkeypatch.setattr(api_services, "_load_returns", lambda: returns)
@@ -136,10 +205,10 @@ def test_predict_ppo_weights_passes_risk_vector_to_env(monkeypatch) -> None:
     monkeypatch.setattr(api_services, "_load_ppo_model", lambda: FakeModel())
     monkeypatch.setattr(rl_env, "PortfolioEnv", FakeEnv)
 
-    weights = api_services._predict_ppo_weights(["SPY", "QQQ"], ["equity_market_risk", "geopolitical_fx_risk"])
-
+    weights = api_services._predict_ppo_weights(["SPY", "QQQ"], [], [])
     assert weights == {"SPY": 0.8, "QQQ": 0.2}
-    assert captured["risk_vector"].tolist() == [0.0, 1.0, 1.0]
+    assert "risk_vector" not in captured["init_kwargs"]
+    assert "set_called" not in captured
 
 
 def test_explain_returns_feature_contributions() -> None:
@@ -255,6 +324,7 @@ def test_research_returns_report_sources_trace_and_risk_tags() -> None:
     assert payload["reasoning_trace"]
     assert isinstance(payload["reasoning_trace"], str)
     assert payload["risk_tags"]
+    assert isinstance(payload["risk_signals"], list)
     assert payload["question"].startswith("금리 인하")
 
 
@@ -274,6 +344,7 @@ def test_research_falls_back_when_graph_raises(monkeypatch) -> None:
     assert payload["status"] in {"ready", "fallback"}
     assert payload["report"]
     assert payload["risk_tags"] == ["macro_rate_risk"]
+    assert payload["risk_signals"] == [{"tag": "macro_rate_risk", "severity": 1.0}]
 
 
 def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> None:
@@ -287,6 +358,7 @@ def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> N
             "sources": ["https://example.com/langgraph"],
             "reasoning_trace": "[THINK][analyst] 완료",
             "rl_risk_tags": ["equity_market_risk"],
+            "risk_signals": [{"tag": "equity_market_risk", "severity": 0.66}],
         }
 
     monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
@@ -301,6 +373,7 @@ def test_research_runs_langgraph_without_fast_or_seed_shortcut(monkeypatch) -> N
     assert payload["report"] == "LangGraph 분석 완료"
     assert payload["sources"] == ["https://example.com/langgraph"]
     assert payload["risk_tags"] == ["equity_market_risk"]
+    assert payload["risk_signals"] == [{"tag": "equity_market_risk", "severity": 0.66}]
     assert calls == ["SPY와 TLT 배분 리스크는?"]
 
 
@@ -332,7 +405,13 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
         yield {
             "event": "on_chain_end",
             "name": "analyst",
-            "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market_risk"]}},
+            "data": {
+                "output": {
+                    "response": "분석 완료",
+                    "risk_tags": ["equity_market_risk"],
+                    "risk_signals": [{"tag": "equity_market_risk", "severity": 0.66}],
+                }
+            },
         }
 
     monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
@@ -358,6 +437,7 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
     assert '"type":"complete"' in lines[-1]
     assert '"report":"분석 완료"' in lines[-1]
     assert "equity_market_risk" in lines[-1]
+    assert '"risk_signals":[{"tag":"equity_market_risk","severity":0.66}]' in lines[-1]
 
 
 def test_research_stream_falls_back_quickly_without_api_key(monkeypatch) -> None:

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -8,6 +8,7 @@ import requests
 
 from apps.dashboard.api_client import (
     build_optimize_payload,
+    extract_risk_signals_from_research_event,
     extract_risk_tags_from_research_event,
     format_research_log_event,
     get_json,
@@ -143,6 +144,7 @@ def test_research_result_from_complete_event() -> None:
         "sources": ["https://example.com"],
         "reasoning_trace": "trace",
         "risk_tags": ["equity_market_risk", "macro_rate_risk"],
+        "risk_signals": [],
     }
 
 
@@ -159,4 +161,24 @@ def test_build_optimize_payload_includes_session_risk_tags() -> None:
     """Dashboard /optimize payload should carry session risk tags."""
     payload = build_optimize_payload(1.5, ["equity_market_risk", "geopolitical_fx_risk"])
 
-    assert payload == {"risk_aversion": 1.5, "risk_tags": ["equity_market_risk", "geopolitical_fx_risk"]}
+    assert payload == {
+        "risk_aversion": 1.5,
+        "risk_tags": ["equity_market_risk", "geopolitical_fx_risk"],
+        "risk_signals": [],
+    }
+
+
+def test_extract_risk_signals_from_research_event_filters_schema() -> None:
+    """Dashboard should keep only valid risk signal rows."""
+    event = {
+        "type": "complete",
+        "risk_signals": [
+            {"tag": "equity_market_risk", "severity": 0.66},
+            {"tag": "unknown", "severity": 1.0},
+            {"tag": "macro_rate_risk", "severity": "bad"},
+        ],
+    }
+
+    assert extract_risk_signals_from_research_event(event) == [
+        {"tag": "equity_market_risk", "severity": 0.66}
+    ]

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -176,6 +176,8 @@ def test_extract_risk_signals_from_research_event_filters_schema() -> None:
             {"tag": "equity_market_risk", "severity": 0.66},
             {"tag": "unknown", "severity": 1.0},
             {"tag": "macro_rate_risk", "severity": "bad"},
+            {"tag": "macro_rate_risk", "severity": 1.0001},
+            {"tag": "geopolitical_fx_risk", "severity": -0.1},
         ],
     }
 


### PR DESCRIPTION
## 관련 이슈
closes #61

## 작업 내용
에이전트에서 감지한 리스크를 RL 최적화까지 전달하는 `risk_signals` 파이프라인을 구현했습니다.

핵심 변경:
- `RiskSignal {tag, severity}` 스키마 추가
- `/research` 응답 및 `/research/stream` complete 이벤트에 `risk_signals` 포함
- `/optimize` 요청이 `risk_signals`를 수용하고 PPO 추론 직전에 `apply_decay(severity, 0, tag)`로 RL 관측 벡터를 구성
- `risk_signals` 없을 때는 legacy `risk_tags`를 `severity=1.0`으로 승격해 호환 유지
- 둘 다 없으면 `PortfolioEnv` 기존 자동 로드(risk_vectors_daily.parquet) fallback 유지

연동 범위:
- API: schemas/services/router
- Agent: `analyst_node`가 `score_risk_vector`로 `risk_signals` 생성
- Dashboard: stream 이벤트에서 `risk_signals`를 session에 저장하고 `/optimize` payload로 전달
- Docs: API/인터페이스/handoff 문서 갱신

## 변경된 파일
| 파일 | 변경 내용 |
|------|---------|
| `apps/api/schemas.py` | `RiskSignal` 및 `risk_signals` 필드 추가 |
| `apps/api/services.py` | signal normalize/vectorize + research/optimize 경로 확장 |
| `apps/api/routers/optimize.py` | `risk_signals` 전달 |
| `src/agent/nodes.py` | analyst에서 `risk_signals` 생성 |
| `src/agent/graph.py` | 초기 상태에 `risk_signals` 추가 |
| `apps/dashboard/api_client.py` | risk_signals 추출/전달 로직 추가 |
| `apps/dashboard/app.py` | 세션 저장 및 optimize payload 반영 |
| `tests/test_api.py` | risk_signals 경로 테스트 보강 |
| `tests/test_dashboard_api_client.py` | dashboard helper 테스트 보강 |
| `docs/api_spec.md` | optimize/research/risk_signals 명세 반영 |
| `docs/labels_and_interfaces.md` | handoff 흐름 업데이트 |
| `docs/risk_signals_handoff.md` | 신규 문서 |

## 테스트 결과
```bash
.venv/bin/python -m pytest tests/test_api.py tests/test_dashboard_api_client.py -q
29 passed, 18 warnings in 12.67s
```

## 체크리스트
- [x] `.env` 파일 커밋 안 함
- [x] 새 함수/클래스에 docstring 작성
- [x] 테스트 통과 확인 (`pytest`)
- [x] PR 대상 브랜치가 `dev`인지 확인

## 기타 참고 사항
- `apps/api/agent.md`는 .gitignore 대상으로 커밋에 포함되지 않았습니다.

Made with [Cursor](https://cursor.com)