### PR TITLE
Docs: RAG 평가 단일 시점 풀 고정 + tag_ok 표기 정정

### DIFF
--- a/docs/chroma_pipeline.md
+++ b/docs/chroma_pipeline.md
@@ -178,6 +178,24 @@ docker compose exec api PYTHONPATH=. python -m src.agent.news_collector
 
 ---
 
+## 4-4. 평가 풀과 운영 풀의 분리
+
+| 풀 | 구성 | 사용처 | 측정 시점 변동성 |
+|----|------|--------|----------------|
+| **평가 풀** | 과거 데이터 1,226건 (FRED + ECOS + manual_seed, GDELT 제외) | `scripts/rag_eval.py` — RAG 품질 평가 | 없음(재현 가능) |
+| **운영 풀** | 평가 풀 + 실시간 Google RSS(수집 시점에 따라 변동) | `/research` API — 실제 사용자 응답 | 있음(RSS 변동) |
+
+RAG 평가의 재현성을 보장하기 위해 평가는 **평가 풀(1,226건)** 기준으로만 수행한다. RAG 평가 수치를 인용할 때는 항상 "1,226건 단일 풀 기준"임을 명시한다. 실시간 RSS는 운영 풀에만 적재되며, 평가에는 포함하지 않는다. 운영 풀에서의 hit·top_dist는 RSS 변동으로 평가 수치와 다를 수 있다.
+
+평가 풀 빌드(권장):
+
+```bash
+PYTHONPATH=. python scripts/build_chroma_from_parquet.py --clear  # 1,226건 적재
+PYTHONPATH=. python scripts/rag_eval.py --json > data/results/rag_eval_snapshot_$(date +%Y%m%d).json
+```
+
+---
+
 ## 5. 알려진 한계 및 향후 개선
 
 | 항목 | 현재 상태 | 개선 방향 |

--- a/docs/rag_eval_results.md
+++ b/docs/rag_eval_results.md
@@ -1,12 +1,14 @@
 # RAG 평가 결과
 
-> **측정일**: 2026-05-23
-> **ChromaDB 상태**: FRED(733) + ECOS(455) + manual_seed(39) + 실시간 RSS(89) = **1,316건**.
-> GDELT(1,197건)는 GKG 기계코드 형식이라 ChromaDB 영구 제외, `risk_vectors_daily.parquet`에만 반영.
+> **측정일**: 2026-05-24
+> **ChromaDB 상태**: FRED(732) + ECOS(455) + manual_seed(39) = **1,226건**.
+> GDELT(1,197건)는 GKG 기계코드 형식이라 ChromaDB 영구 제외, `risk_vectors_daily.parquet` 집계에만 반영.
+> **실시간 RSS는 평가 풀에서 제외**(재현성 확보). 운영(`/research`) 시에는 별도 수집 스케줄로 추가 적재됨.
+> **재빌드 명령**: `PYTHONPATH=. python scripts/build_chroma_from_parquet.py --clear`
 > **평가 스크립트**: `PYTHONPATH=. python scripts/rag_eval.py --json`
 > **평가 질문**: `docs/rag_eval_questions.json` (12문항)
-> **검색 파라미터**: `n_results=3`, `hit_threshold=0.4` (cosine distance)
-> **리스크 태그 체계**: 신버전 3축 — `macro_rate_risk` / `equity_market_risk` / `geopolitical_fx_risk` (`_risk` suffix 통일, PR #48 머지본)
+> **검색 파라미터**: `n_results=3`, `hit_threshold=0.4` (cosine distance, ChromaDB 기본 임베딩 `all-MiniLM-L6-v2`)
+> **리스크 태그 체계**: 신버전 3축 — `macro_rate_risk` / `equity_market_risk` / `geopolitical_fx_risk` (`_risk` suffix 통일)
 
 ---
 
@@ -15,10 +17,12 @@
 | 지표 | 결과 |
 |------|------|
 | 검색 히트율 (top-1 cosine dist < 0.4) | **12 / 12 = 100%** |
-| 태그 정확도 (expect ⊆ found_tags) | **12 / 12 = 100%** |
-| top_dist 평균 | 0.246 (범위 0.203 ~ 0.367) |
+| 태그 매칭률 `tag_ok` (`expect ∩ found ≠ ∅`) | **12 / 12 = 100%** |
+| top_dist 평균 | 0.248 |
+| top_dist 범위 | 0.203 ~ 0.367 |
+| 메타데이터 회수 (`date`, `risk_label` 필드) | 12 / 12 |
 
-> ⚠️ 태그 정확도 100%의 변별력 한계: 검색이 `n_results=3`이고 3축 태그 풀이 작아 **거의 모든 질문에서 3 태그가 동시에 회수**된다. `tag_ok`는 "기대 태그가 found_tags에 포함되는가" 조건이라 사실상 자동 통과. 실제 1위 문서의 정확도는 `top_dist`(0.20~0.37대 일관)와 `top_doc` 정성 검토로 보완 판단해야 한다.
+> ⚠️ **`tag_ok` 지표의 정확한 정의**: `scripts/rag_eval.py` line 69 `tag_ok = bool(expect & found)` — **기대 태그 집합과 검색된 태그 집합의 교집합이 비어 있지 않은지** 확인하는 조건이다(부분집합 조건이 아님). 기대 태그 중 하나라도 회수되면 통과한다. `n_results=3` 검색에서 3축 태그가 거의 모든 질문에서 동시에 회수되므로 사실상 자동 통과에 가깝다. 실제 1위 문서의 적절성은 `top_dist`(전 구간 0.4 미만)와 `top_doc` 정성 검토로 보완 판단한다.
 
 ---
 
@@ -26,37 +30,41 @@
 
 | id | 질문 (요약) | hit | top_dist | expect | found_tags | tag_ok |
 |----|-------------|-----|----------|--------|------------|--------|
-| Q01 | 금리 인상이 ETF 포트폴리오에 미치는 영향 | ✅ | 0.2079 | macro_rate_risk | macro/equity/geo 3종 | ✅ |
-| Q02 | 한국 금융당국 규제 강화·정책 변경 시 투자 리스크 | ✅ | 0.2362 | geopolitical_fx_risk | macro/equity/geo 3종 | ✅ |
-| Q03 | 코스피 급락·변동성 확대 시 포트폴리오 리스크 | ✅ | 0.2030 | equity_market_risk | macro/equity/geo 3종 | ✅ |
-| Q04 | 어닝쇼크·실적 부진 관련 최근 증시 리스크 | ✅ | 0.2090 | equity_market_risk | macro/equity/geo 3종 | ✅ |
-| Q05 | 미국 연준 기준금리 결정이 한국 채권 ETF에 미치는 영향 | ✅ | 0.2586 | macro_rate_risk | macro/equity/geo 3종 | ✅ |
-| Q06 | 원달러 환율 급등 시 포트폴리오 리스크 관리 | ✅ | 0.2070 | geopolitical_fx_risk | macro/equity/geo 3종 | ✅ |
-| Q07 | 지정학적 리스크(전쟁·무역분쟁)가 국내 증시에 미치는 영향 | ✅ | 0.2755 | equity/geo | macro/equity/geo 3종 | ✅ |
-| Q08 | 인플레이션 상승이 자산 배분 전략에 미치는 영향 | ✅ | 0.2975 | macro_rate_risk | macro/equity/geo 3종 | ✅ |
-| Q09 | 시장 변동성 VIX 지수 급등 시 방어적 포트폴리오 구성 | ✅ | 0.3674 | equity_market_risk | macro/equity/geo 3종 | ✅ |
-| Q10 | 공급망 차질·원자재 가격 급등이 ETF 수익률에 미치는 영향 | ✅ | 0.2052 | macro/geo | macro/equity/geo 3종 | ✅ |
-| Q11 | 한국은행 기준금리 인상이 부동산·채권 시장에 미치는 영향 | ✅ | 0.2626 | macro_rate_risk | macro/equity/geo 3종 | ✅ |
-| Q12 | 글로벌 경기침체 우려가 국내 주식형 ETF에 미치는 리스크 | ✅ | 0.2519 | macro/equity | macro/equity/geo 3종 | ✅ |
+| Q01 | 금리 인상이 ETF 포트폴리오에 미치는 영향 | OK | 0.2079 | macro | macro/equity/geo | OK |
+| Q02 | 한국 금융당국 규제 강화·정책 변경 시 투자 리스크 | OK | 0.2362 | geo | macro/equity/geo | OK |
+| Q03 | 코스피 급락·변동성 확대 시 포트폴리오 리스크 | OK | 0.2030 | equity | macro/equity/geo | OK |
+| Q04 | 어닝쇼크·실적 부진 관련 최근 증시 리스크 | OK | 0.2090 | equity | macro/equity/geo | OK |
+| Q05 | 미국 연준 기준금리 결정이 한국 채권 ETF에 미치는 영향 | OK | 0.2586 | macro | macro/equity/geo | OK |
+| Q06 | 원달러 환율 급등 시 포트폴리오 리스크 관리 | OK | 0.2070 | geo | macro/equity/geo | OK |
+| Q07 | 지정학적 리스크(전쟁·무역분쟁)가 국내 증시에 미치는 영향 | OK | 0.2755 | equity, geo | macro/equity/geo | OK |
+| Q08 | 인플레이션 상승이 자산 배분 전략에 미치는 영향 | OK | 0.2975 | macro | macro/equity/geo | OK |
+| Q09 | 시장 변동성 VIX 지수 급등 시 방어적 포트폴리오 구성 | OK | 0.3674 | equity | macro/equity/geo | OK |
+| Q10 | 공급망 차질·원자재 가격 급등이 ETF 수익률에 미치는 영향 | OK | 0.2052 | macro, geo | macro/equity/geo | OK |
+| Q11 | 한국은행 기준금리 인상이 부동산·채권 시장에 미치는 영향 | OK | 0.2626 | macro | macro/equity/geo | OK |
+| Q12 | 글로벌 경기침체 우려가 국내 주식형 ETF에 미치는 리스크 | OK | 0.2519 | macro, equity | macro/equity/geo | OK |
 
 ---
 
 ## 유효한 검증 항목
 
 - **검색 파이프라인 작동**: 12/12 (`top_dist < 0.4` 통과)
-- **리포트 생성 성공**: 12/12 (별도 graph 실행 시 검증)
-- **출처 메타데이터 존재**: 12/12 (`top_doc`·`top_date` 모두 반환)
-- **신규 태그 체계 적용 확인**: 모든 `found_tags`가 `_risk` suffix 신버전으로 회수됨 (구버전 `equity_market`·`macro_rate` 잔재 없음)
-- **태그 분포 균형**: 12 질문 전반에서 macro / equity / geo 3 태그가 골고루 회수됨
+- **메타데이터 회수**: 12/12 (`date`·`risk_label` 모두 회수, `top_doc`/`top_date` 출력 확인). URL·source 등 추가 메타데이터 회수 여부는 별도 컬렉션 dump로 확인 예정.
+- **신규 태그 체계 적용**: 모든 `found_tags`가 `_risk` suffix 신버전으로 회수됨(구버전 `equity_market`·`macro_rate` 잔재 없음).
+- **태그 분포 균형**: 12 질문 전반에서 macro / equity / geo 3 태그가 골고루 회수됨.
 
 ## 변별력이 약한 항목
 
-- **`tag_ok` 100%의 의미 제한**: `n_results=3`에서 거의 모든 질문이 3 태그를 동시에 회수하므로 부분집합 포함(`expect ⊆ found`) 조건이 자동 통과. 평가의 변별력은 `top_dist`(0.20~0.37)와 `top_doc` 정성 검토에 의존.
-- **개선 방향**: 평가 기준을 "1위 문서의 primary_tag가 expect와 정확 일치"로 강화하거나, expect 셋이 다중인 질문에서 `len(found ∩ expect) / len(expect)` precision metric 도입.
+- **`tag_ok` 100%의 의미 제한**: 위 요약 표 주석 참조. `n_results=3` + 3축 태그 풀이라는 구조적 이유로 `tag_ok`가 사실상 자동 통과.
+- **개선 metric 후보**:
+  - 1위 문서의 `primary_tag` 메타데이터가 expect와 정확 일치하는지 확인.
+  - `precision = |found ∩ expect| / |found|`, `recall = |found ∩ expect| / |expect|`.
+  - MRR(Mean Reciprocal Rank), Recall@k.
 
-## 이전(2026-05-22) 측정값과의 차이
+## 평가 범위의 한계
 
-PR #51 description / `docs/임시_유영_분석보고서.md` 이전 판본에 적힌 **"태그 정확도 10/12 = 83.3%, 실패 2건: Q08·Q11"** 수치는 ChromaDB 데이터 보강 전(부분 적재) 측정값. 본 평가일(2026-05-23) 기준으로는 12/12로 갱신됨. 보고서 §6 수치도 동일하게 갱신 예정.
+- **검색 단계 단일 호출만 평가**: 본 평가는 ChromaDB 검색 1회로만 수행된다. LangGraph 기반 Self-Correction 재검색 루프, 리포트 생성 단계(`/research/stream`), risk_tags 후처리는 본 평가 범위 밖이며, Self-Correction 효과는 별도 시나리오 테스트로 후속 검증한다.
+- **평가 풀 도메인 편향**: ChromaDB 적재 풀이 FRED(매크로·금리 중심) + ECOS(매크로·환율) + manual_seed(소량 큐레이션)로 구성되어 equity·geo 도메인 비중이 macro 대비 얕다. 이는 모든 질문에서 3 태그가 동시에 회수되는 현상의 한 원인.
+- **운영 풀과의 분리**: 본 평가 수치는 과거 데이터 풀(1,226건)이며 운영 시 실시간 RSS가 추가된 풀(시점에 따라 변동)에서는 hit·top_dist가 다소 달라질 수 있다.
 
 ---
 


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용
RAG 평가 수치의 재현성을 확보하기 위해 평가 풀을 과거 데이터(1,226건, GDELT 제외)로 고정하고, 2026-05-24 단일 시점으로 재측정한 결과를 보고서에 반영했다. 동시에 `tag_ok` 지표를 잘못 "부분집합 조건"으로 기술한 표기 오류와 top_dist 평균 수치 오차를 정정했다.

- ChromaDB를 깨끗이 초기화 후 `scripts/build_chroma_from_parquet.py --clear`로 재빌드 → `coll.count() = 1,226` 확정 (FRED 732 + ECOS 455 + manual_seed 39, 날짜 범위 2018-02-02 ~ 2025-12-29)
- 같은 풀에서 `scripts/rag_eval.py --json` 재측정 → 12/12 hit, 12/12 tag_ok, top_dist min=0.203 / max=0.367 / 평균=0.248
- `docs/rag_eval_results.md` 전면 갱신
  - 헤더 ChromaDB 건수 1,316 → 1,226 (실시간 RSS 제외 정책 명시)
  - top_dist 평균 0.246 → 0.248 (raw 12개 값 직접 계산)
  - `tag_ok` 설명을 "부분집합 조건"에서 코드와 일치하는 "교집합 비어 있지 않음"(`bool(expect & found)`)으로 정정
  - 평가 범위 한계 항목 신설(Self-Correction 미측정·도메인 편향·운영 풀과의 분리)
  - 후속 metric 후보 4종 명시(primary_tag exact / precision / recall / MRR / Recall@k)
  - 임베딩 모델(`all-MiniLM-L6-v2`)·거리 함수(cosine) 명시
- `docs/chroma_pipeline.md` §4-4 신설 — 평가 풀(1,226, 재현 가능)과 운영 풀(평가 풀 + RSS, 시점 변동)을 표로 분리, 평가 풀 빌드 명령 안내

## 변경된 파일
| 파일 | 변경 내용 |
|------|---------|
| `docs/rag_eval_results.md` | 헤더 1,316→1,226, top_dist 평균 0.246→0.248, tag_ok 정의 정정, 평가 범위 한계 신설, 후속 metric 후보 구체화 |
| `docs/chroma_pipeline.md` | §4-4 신설: 평가 풀 vs 운영 풀 분리 정책 및 평가 풀 빌드 명령 안내 |

## 테스트 결과
```
$ PYTHONPATH=. python scripts/build_chroma_from_parquet.py --clear
INFO unified 로드: 2423건
INFO GDELT 제외: 2423 -> 1226건
INFO 완료: 1226건 업서트, 컬렉션 0 -> 1226건

=== 소스별 분포 ===
fred           732
ecos           455
manual_seed     39

$ PYTHONPATH=. python scripts/rag_eval.py --json | jq '{hit_rate, tag_accuracy}'
{
  "hit_rate": 1.0,
  "tag_accuracy": 1.0
}

# top_dist 직접 계산
min=0.2030, max=0.3674, mean=0.2485 (→ 0.248)
```

## 체크리스트
- [x] 담당 파일 외 다른 팀원 파일 무단 수정 없음 (docs 2개만 수정)
- [x] `.env` 파일 커밋 안 함
- [x] 새 함수/클래스에 docstring 작성 (코드 변경 없음)
- [x] 테스트 통과 확인 (`scripts/build_chroma_from_parquet.py --clear` + `scripts/rag_eval.py --json` 정상 종료)
- [x] PR 대상 브랜치가 `dev`인지 확인 (셀프 merge 금지)

## 기타 참고 사항
- 본 PR은 코드/데이터 빌더는 건드리지 않고 문서만 정정합니다. 다른 분석 산출물(백테스트·SHAP·ANOVA)에는 영향 없습니다.
- `tag_ok = bool(expect & found)` 표기 정정은 코드 동작 변경이 아니라 문서 기술 오류 수정입니다. 본 PR 이후 보고서·발표 자료에서도 "교집합 비어 있지 않음"으로 일관 사용 권장.
- 평가 풀(1,226건)을 단일 기준으로 고정함에 따라, 향후 모든 RAG 평가 수치는 동일 풀에서 재현 가능. 운영 풀(RSS 포함)은 별도 노트로 분리 인용.