### PR TITLE
Fix :  Enhance dashboard API client and portfolio handling

### DIFF
--- a/apps/api/observability.py
+++ b/apps/api/observability.py
@@ -1,0 +1,33 @@
+"""Small structured logs for Docker-based E2E inspection."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger("apps.api.e2e")
+uvicorn_logger = logging.getLogger("uvicorn.error")
+
+
+def log_e2e_event(
+    endpoint: str,
+    *,
+    status: str,
+    elapsed_ms: float = 0.0,
+    timed_out: bool = False,
+    **fields: Any,
+) -> None:
+    """Emit one grep-friendly JSON log line for an API endpoint result."""
+    payload: dict[str, Any] = {
+        "event": "e2e_endpoint",
+        "endpoint": endpoint,
+        "status": status,
+        "elapsed_ms": round(float(elapsed_ms), 3),
+        "timed_out": bool(timed_out),
+        **fields,
+    }
+    message = f"E2E {json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)}"
+    logger.info(message)
+    if uvicorn_logger is not logger:
+        uvicorn_logger.info(message)

--- a/apps/api/routers/backtest.py
+++ b/apps/api/routers/backtest.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query
 
+from apps.api.observability import log_e2e_event
 from apps.api.schemas import BacktestResponse, BacktestWindow
 from apps.api.services import build_backtest_response
 
@@ -15,4 +16,15 @@ def get_backtest(
     window: Annotated[BacktestWindow, Query(description="Walk-forward backtest window")] = "final",
 ) -> BacktestResponse:
     """Return backtest metrics and ANOVA summaries."""
-    return build_backtest_response(window=window)
+    response = build_backtest_response(window=window)
+    log_e2e_event(
+        "/backtest",
+        status=response.status,
+        elapsed_ms=response.elapsed_ms,
+        timed_out=response.timed_out,
+        window=window,
+        metrics_count=len(response.metrics),
+        anova_count=len(response.anova),
+        safeguard_active=response.safeguard.active,
+    )
+    return response

--- a/apps/api/routers/explain.py
+++ b/apps/api/routers/explain.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from apps.api.observability import log_e2e_event
 from apps.api.schemas import ExplainRequest, ExplainResponse
 from apps.api.services import build_explanation_response
 
@@ -11,4 +12,20 @@ router = APIRouter(tags=["explainability"])
 @router.post("/explain", response_model=ExplainResponse)
 def explain_decision(request: ExplainRequest) -> ExplainResponse:
     """Return feature contributions for a requested date."""
-    return build_explanation_response(request.date, request.top_k)
+    response = build_explanation_response(request.date, request.top_k)
+    feature_reasoning_count = sum(
+        len(item.reasoning_context) for item in response.feature_contributions
+    )
+    log_e2e_event(
+        "/explain",
+        status=response.status,
+        elapsed_ms=response.elapsed_ms,
+        timed_out=response.timed_out,
+        requested_date=request.date,
+        target_date=response.target_date,
+        top_k=request.top_k,
+        features_count=len(response.feature_contributions),
+        reasoning_count=len(response.reasoning_context),
+        feature_reasoning_count=feature_reasoning_count,
+    )
+    return response

--- a/apps/api/routers/optimize.py
+++ b/apps/api/routers/optimize.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from apps.api.observability import log_e2e_event
 from apps.api.schemas import OptimizeRequest, OptimizeResponse
 from apps.api.services import build_portfolio_response
 
@@ -11,10 +12,22 @@ router = APIRouter(tags=["portfolio"])
 @router.post("/optimize", response_model=OptimizeResponse)
 def optimize_portfolio(request: OptimizeRequest) -> OptimizeResponse:
     """Return normalized portfolio weights."""
-    return build_portfolio_response(
+    response = build_portfolio_response(
         tickers=request.tickers,
         risk_profile=request.risk_profile,
         risk_aversion=request.risk_aversion,
         risk_tags=request.risk_tags,
         risk_signals=request.risk_signals,
     )
+    log_e2e_event(
+        "/optimize",
+        status=response.status,
+        elapsed_ms=response.elapsed_ms,
+        timed_out=response.timed_out,
+        tickers_count=len(response.tickers),
+        weights_count=len(response.weights),
+        risk_profile=response.risk_profile,
+        risk_tags_count=len(request.risk_tags or []),
+        risk_signals_count=len(request.risk_signals or []),
+    )
+    return response

--- a/apps/api/routers/research.py
+++ b/apps/api/routers/research.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
+from apps.api.observability import log_e2e_event
 from apps.api.schemas import ResearchRequest, ResearchResponse
 from apps.api.services import build_research_response, stream_research_response
 
@@ -12,7 +13,18 @@ router = APIRouter(tags=["research"])
 @router.post("/research", response_model=ResearchResponse)
 def research_question(request: ResearchRequest) -> ResearchResponse:
     """Return investment research report data."""
-    return build_research_response(request.question)
+    response = build_research_response(request.question)
+    log_e2e_event(
+        "/research",
+        status=response.status,
+        elapsed_ms=response.elapsed_ms,
+        timed_out=response.timed_out,
+        sources_count=len(response.sources),
+        risk_tags_count=len(response.risk_tags),
+        risk_signals_count=len(response.risk_signals),
+        report_chars=len(response.report),
+    )
+    return response
 
 
 @router.post("/research/stream")

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -21,6 +21,7 @@ import pandas as pd
 from pydantic import ValidationError
 
 from apps.api.config import settings
+from apps.api.observability import log_e2e_event
 from apps.api.schemas import (
     AnovaResult,
     BacktestResponse,
@@ -312,10 +313,21 @@ async def stream_graph_events(question: str) -> AsyncIterator[dict[str, Any]]:
 
 async def stream_research_response(question: str) -> AsyncIterator[str]:
     """Stream research progress as newline-delimited JSON for Streamlit."""
+    start = perf_counter()
     yield _to_ndjson({"type": "start", "question": question})
 
     if not settings.OPENAI_API_KEY:
         fallback = build_fallback_research(question)
+        log_e2e_event(
+            "/research/stream",
+            status=fallback.status,
+            elapsed_ms=_elapsed_ms(start),
+            timed_out=fallback.timed_out,
+            sources_count=len(fallback.sources),
+            risk_tags_count=len(fallback.risk_tags),
+            risk_signals_count=len(fallback.risk_signals),
+            report_chars=len(fallback.report),
+        )
         yield _to_ndjson(
             {
                 "type": "fallback",
@@ -336,6 +348,17 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
                 yield _to_ndjson(compact)
     except Exception as exc:
         fallback = build_fallback_research(question)
+        log_e2e_event(
+            "/research/stream",
+            status=fallback.status,
+            elapsed_ms=_elapsed_ms(start),
+            timed_out=fallback.timed_out,
+            sources_count=len(fallback.sources),
+            risk_tags_count=len(fallback.risk_tags),
+            risk_signals_count=len(fallback.risk_signals),
+            report_chars=len(fallback.report),
+            error=exc.__class__.__name__,
+        )
         yield _to_ndjson(
             {
                 "type": "fallback",
@@ -349,6 +372,16 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
         return
 
     response = _research_response_from_state(question, final_state or {})
+    log_e2e_event(
+        "/research/stream",
+        status=response.status,
+        elapsed_ms=_elapsed_ms(start),
+        timed_out=response.timed_out,
+        sources_count=len(response.sources),
+        risk_tags_count=len(response.risk_tags),
+        risk_signals_count=len(response.risk_signals),
+        report_chars=len(response.report),
+    )
     yield _to_ndjson(
         {
             "type": "complete",

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -19,6 +19,59 @@ _RESEARCH_NODE_LABELS = {
 }
 
 
+def calculate_period_return_metrics(
+    portfolio_cumulative: list[float],
+    benchmark_cumulative: list[float],
+) -> tuple[float, float]:
+    """Return selected-period cumulative and excess returns from cumulative wealth indexes."""
+    if not portfolio_cumulative or not benchmark_cumulative:
+        return 0.0, 0.0
+
+    portfolio_start = float(portfolio_cumulative[0])
+    benchmark_start = float(benchmark_cumulative[0])
+    if portfolio_start <= 0 or benchmark_start <= 0:
+        return 0.0, 0.0
+
+    portfolio_return = float(portfolio_cumulative[-1]) / portfolio_start - 1.0
+    benchmark_return = float(benchmark_cumulative[-1]) / benchmark_start - 1.0
+    return portfolio_return, portfolio_return - benchmark_return
+
+
+def explain_reasoning_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten SHAP response reasoning context for dashboard display."""
+    rows: list[dict[str, Any]] = []
+
+    def append_rows(scope: str, feature: str, events: Any) -> None:
+        if not isinstance(events, list):
+            return
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            rows.append(
+                {
+                    "구분": scope,
+                    "피처": feature,
+                    "날짜": str(event.get("event_date", "")),
+                    "태그": str(event.get("tag", "")),
+                    "강도": event.get("severity", 0.0),
+                    "감쇠점수": event.get("decayed_score", 0.0),
+                    "근거": str(event.get("reasoning", "")),
+                    "출처": str(event.get("source", "")),
+                }
+            )
+
+    append_rows("전체", "", payload.get("reasoning_context"))
+    for contribution in payload.get("feature_contributions", []):
+        if not isinstance(contribution, dict):
+            continue
+        append_rows(
+            "피처",
+            str(contribution.get("feature", "")),
+            contribution.get("reasoning_context"),
+        )
+    return rows
+
+
 def _mock_warning_message(endpoint: str, exc: Exception) -> str:
     """Return a user-facing warning when the dashboard falls back to mock data."""
     return f"API 연결 실패 ({endpoint}): {exc} — 이는 mock 응답입니다."

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -19,6 +19,11 @@ _RESEARCH_NODE_LABELS = {
 }
 
 
+def _build_url(base_url: str, endpoint: str) -> str:
+    """Join a dashboard base URL and endpoint without double slashes."""
+    return f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+
+
 def calculate_period_return_metrics(
     portfolio_cumulative: list[float],
     benchmark_cumulative: list[float],
@@ -209,7 +214,7 @@ def get_json(
 ) -> dict[str, Any] | None:
     """Perform a GET request and return JSON, or fall back to None."""
     try:
-        resp = requests.get(f"{base_url}{endpoint}", params=params, timeout=timeout)
+        resp = requests.get(_build_url(base_url, endpoint), params=params, timeout=timeout)
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException as exc:
@@ -232,7 +237,7 @@ def post_json(
 ) -> dict[str, Any] | None:
     """Perform a POST request and return JSON, or fall back to None."""
     try:
-        resp = requests.post(f"{base_url}{endpoint}", json=payload, timeout=timeout)
+        resp = requests.post(_build_url(base_url, endpoint), json=payload, timeout=timeout)
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException as exc:
@@ -257,7 +262,7 @@ def stream_ndjson(
     """Stream newline-delimited JSON events as formatted strings."""
     try:
         with requests.post(
-            f"{base_url}{endpoint}",
+            _build_url(base_url, endpoint),
             json=payload,
             stream=True,
             timeout=timeout,

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -58,8 +58,8 @@ def explain_reasoning_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
                     "피처": feature,
                     "날짜": str(event.get("event_date", "")),
                     "태그": str(event.get("tag", "")),
-                    "강도": event.get("severity", 0.0),
-                    "감쇠점수": event.get("decayed_score", 0.0),
+                    "강도": float(event.get("severity") or 0.0),
+                    "감쇠점수": float(event.get("decayed_score") or 0.0),
                     "근거": str(event.get("reasoning", "")),
                     "출처": str(event.get("source", "")),
                 }

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -287,16 +287,61 @@ _rng = np.random.default_rng(42)
 
 
 def _mock_optimize(risk_aversion: float = 1.0) -> dict:
-    w = _rng.dirichlet(np.ones(len(_ASSETS)) * (1 / risk_aversion))
+    seed = 4242 + int(round(float(risk_aversion) * 1000))
+    rng = np.random.default_rng(seed)
+    concentration = np.full(len(_ASSETS), 1.0 / max(float(risk_aversion), 0.1))
+    weights = rng.dirichlet(concentration)
+    portfolio_daily = rng.normal(0.0005, 0.012, 252)
+    benchmark_daily = rng.normal(0.0003, 0.010, 252)
+    portfolio_cum = np.cumprod(1 + portfolio_daily)
+    benchmark_cum = np.cumprod(1 + benchmark_daily)
     dates = pd.date_range("2024-01-01", periods=252, freq="B").strftime("%Y-%m-%d").tolist()
+    portfolio_return = float(portfolio_cum[-1] / portfolio_cum[0] - 1.0)
     return {
-        "weights": dict(zip(_ASSETS, w.tolist())),
+        "status": "mock",
+        "message": "API 연결 실패로 mock 포트폴리오를 표시합니다.",
+        "elapsed_ms": 0.0,
+        "timed_out": False,
+        "tickers": list(_ASSETS),
+        "weights": dict(zip(_ASSETS, weights.tolist())),
+        "risk_profile": "balanced",
+        "expected_return": round(portfolio_return, 6),
+        "expected_volatility": round(float(np.std(portfolio_daily, ddof=1) * np.sqrt(252)), 6),
         "returns": {
             "date": dates,
-            "portfolio": np.cumprod(1 + _rng.normal(0.0005, 0.012, 252)).tolist(),
-            "benchmark": np.cumprod(1 + _rng.normal(0.0003, 0.010, 252)).tolist(),
+            "portfolio": portfolio_cum.tolist(),
+            "benchmark": benchmark_cum.tolist(),
         },
     }
+
+
+def _ensure_portfolio_data(
+    risk_aversion: float,
+    current_risk_tags: list[str],
+    current_risk_signals: list[dict[str, Any]],
+    *,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Return the latest portfolio result, refreshing only when requested."""
+    cached_data = st.session_state.get("portfolio_data")
+    if cached_data and not refresh:
+        return cached_data
+
+    payload = build_optimize_payload(risk_aversion, current_risk_tags, current_risk_signals)
+    with st.spinner("POST /optimize 호출 중…"):
+        data = _post("/optimize", payload)
+
+    if not data:
+        data = _mock_optimize(risk_aversion)
+    else:
+        data = dict(data)
+        data.setdefault("status", "ready")
+        data.setdefault("message", "포트폴리오 최적화 결과입니다.")
+
+    st.session_state["portfolio_data"] = data
+    st.session_state["portfolio_payload"] = payload
+    st.session_state["portfolio_updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return data
 
 
 def _mock_backtest() -> dict:
@@ -507,16 +552,13 @@ def portfolio_page() -> None:
         caption += f" | 저장 시각: {latest_updated_at}"
     st.caption(caption)
 
-    if st.button("최적화 실행", key="btn_optimize"):
-        with st.spinner("POST /optimize 호출 중…"):
-            payload = build_optimize_payload(
-                risk_aversion,
-                current_risk_tags,
-                current_risk_signals,
-            )
-            data = _post("/optimize", payload) or _mock_optimize(risk_aversion)
-    else:
-        data = _mock_optimize(risk_aversion)
+    refresh_requested = st.button("최적화 실행", key="btn_optimize")
+    data = _ensure_portfolio_data(
+        risk_aversion,
+        current_risk_tags,
+        current_risk_signals,
+        refresh=refresh_requested or "portfolio_data" not in st.session_state,
+    )
 
     # 기간 슬라이싱
     n = _PERIOD_MONTHS[period]
@@ -524,13 +566,22 @@ def portfolio_page() -> None:
     x = ret["date"][-n:] if n else ret["date"]
     port_vals = ret["portfolio"][-n:] if n else ret["portfolio"]
     bm_vals = ret["benchmark"][-n:] if n else ret["benchmark"]
+    data_status = data.get("status", "unknown")
+    data_message = data.get("message", "")
+    elapsed_ms = float(data.get("elapsed_ms", 0.0) or 0.0)
+    data_start = x[0] if x else "-"
+    data_end = x[-1] if x else "-"
+    st.caption(
+        f"상태: {data_status} | 메시지: {data_message} | 소요 시간: {elapsed_ms:.1f}ms | "
+        f"데이터 기간: {data_start} ~ {data_end}"
+    )
 
     cum_ret, excess = calculate_period_return_metrics(port_vals, bm_vals)
     top_asset = max(data["weights"], key=data["weights"].get)
 
     k1, k2, k3, k4 = st.columns(4)
     k1.metric("누적 수익률", f"{cum_ret:.1%}", border=True)
-    k2.metric("초과 수익", f"{excess:.1%}", delta=f"{excess:.2%} vs KOSPI", border=True)
+    k2.metric("초과 수익", f"{excess:.1%}", delta=f"{excess:.2%} vs SPY", border=True)
     k3.metric("최대 비중 자산", top_asset, f"{data['weights'][top_asset]:.1%}", border=True)
     k4.metric("편입 종목 수", f"{len(data['weights'])}개", border=True)
 
@@ -557,7 +608,7 @@ def portfolio_page() -> None:
                         "itemStyle": {"color": _PALETTE[0]},
                     },
                     {
-                        "name": "벤치마크(KOSPI)",
+                        "name": "벤치마크(SPY)",
                         "type": "line",
                         "smooth": True,
                         "data": bm_vals,

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -323,11 +323,11 @@ def _ensure_portfolio_data(
     refresh: bool = False,
 ) -> dict[str, Any]:
     """Return the latest portfolio result, refreshing only when requested."""
+    payload = build_optimize_payload(risk_aversion, current_risk_tags, current_risk_signals)
     cached_data = st.session_state.get("portfolio_data")
+
     if cached_data and not refresh:
         return cached_data
-
-    payload = build_optimize_payload(risk_aversion, current_risk_tags, current_risk_signals)
     with st.spinner("POST /optimize 호출 중…"):
         data = _post("/optimize", payload)
 
@@ -553,6 +553,16 @@ def portfolio_page() -> None:
     st.caption(caption)
 
     refresh_requested = st.button("최적화 실행", key="btn_optimize")
+
+    current_payload = build_optimize_payload(risk_aversion, current_risk_tags, current_risk_signals)
+    cached_payload = st.session_state.get("portfolio_payload")
+    if (
+        cached_payload is not None
+        and cached_payload != current_payload
+        and not refresh_requested
+    ):
+        st.warning("설정이 변경되었습니다. '최적화 실행'을 다시 눌러 결과를 업데이트하세요.")
+
     data = _ensure_portfolio_data(
         risk_aversion,
         current_risk_tags,

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -23,6 +23,8 @@ try:
     from apps.dashboard.api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
+        calculate_period_return_metrics,
+        explain_reasoning_rows,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -36,6 +38,8 @@ except ModuleNotFoundError:
     from api_client import (
         RL_RISK_TAGS,
         build_optimize_payload,
+        calculate_period_return_metrics,
+        explain_reasoning_rows,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -521,10 +525,7 @@ def portfolio_page() -> None:
     port_vals = ret["portfolio"][-n:] if n else ret["portfolio"]
     bm_vals = ret["benchmark"][-n:] if n else ret["benchmark"]
 
-    ret_arr = np.array(port_vals)
-    bm_arr = np.array(bm_vals)
-    cum_ret = float(ret_arr[-1] - 1)
-    excess = float(ret_arr[-1] - bm_arr[-1])
+    cum_ret, excess = calculate_period_return_metrics(port_vals, bm_vals)
     top_asset = max(data["weights"], key=data["weights"].get)
 
     k1, k2, k3, k4 = st.columns(4)
@@ -750,6 +751,14 @@ def shap_page() -> None:
                 title="Force Plot (빨강=양, 파랑=음)",
                 key="shap_force",
             )
+
+    reasoning_rows = explain_reasoning_rows(sd)
+    with st.container(border=True):
+        st.markdown("**Reasoning Context**")
+        if reasoning_rows:
+            st.dataframe(pd.DataFrame(reasoning_rows), hide_index=True, use_container_width=True)
+        else:
+            st.caption("해당 분석 날짜와 top SHAP 피처에 연결된 reasoning context가 없습니다.")
 
 
 def research_page() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """FastAPI Sprint 2 endpoint contract tests."""
 
 import json
+import logging
 import math
 import time
 from concurrent.futures import TimeoutError
@@ -66,6 +67,31 @@ def test_optimize_accepts_dashboard_risk_aversion_and_returns_series() -> None:
     assert len(returns["date"]) == len(returns["portfolio"]) == len(returns["benchmark"])
     assert all(value > 0 for value in returns["portfolio"])
     assert all(value > 0 for value in returns["benchmark"])
+
+
+def test_optimize_emits_e2e_log(caplog) -> None:
+    """POST /optimize should emit one structured E2E log for Docker inspection."""
+    caplog.set_level(logging.INFO, logger="apps.api.e2e")
+    caplog.set_level(logging.INFO, logger="uvicorn.error")
+
+    response = client.post("/optimize", json={"risk_aversion": 1.5})
+
+    assert response.status_code == 200
+    events = [
+        json.loads(record.message.removeprefix("E2E "))
+        for record in caplog.records
+        if record.name == "apps.api.e2e" and record.message.startswith("E2E ")
+    ]
+    assert any(
+        event["endpoint"] == "/optimize"
+        and event["status"] in {"ready", "fallback"}
+        and event["tickers_count"] == len(EXPECTED_TICKERS)
+        for event in events
+    )
+    assert any(
+        record.name == "uvicorn.error" and record.message.startswith("E2E ")
+        for record in caplog.records
+    )
 
 
 def test_optimize_uses_ready_ppo_weights_when_available(monkeypatch) -> None:

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -64,6 +64,60 @@ def test_get_json_returns_payload_on_success(monkeypatch) -> None:
     assert result == {"status": "ok"}
 
 
+def test_api_helpers_strip_trailing_slash_from_base_url(monkeypatch) -> None:
+    """HTTP helpers should normalize trailing slashes in the base URL."""
+    captured: list[str] = []
+
+    def fake_get(url: str, **kwargs: Any) -> _DummyResponse:
+        captured.append(url)
+        return _DummyResponse({"status": "ok"})
+
+    class _DummyStream:
+        def __enter__(self) -> "_DummyStream":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_lines(self) -> list[bytes]:
+            return [b'{"type":"complete"}']
+
+    def fake_post(url: str, **kwargs: Any) -> _DummyResponse | _DummyStream:
+        captured.append(url)
+        if kwargs.get("stream"):
+            return _DummyStream()
+        return _DummyResponse({"status": "ok"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    assert get_json("http://localhost:8000/", "/health", timeout=3) == {"status": "ok"}
+    assert post_json(
+        "http://localhost:8000/",
+        "/optimize",
+        {"risk_aversion": 1.5},
+        timeout=3,
+    ) == {"status": "ok"}
+
+    list(
+        stream_ndjson(
+            "http://localhost:8000/",
+            "/research/stream",
+            {"question": "q"},
+            formatter=lambda event: "",
+        )
+    )
+
+    assert captured == [
+        "http://localhost:8000/health",
+        "http://localhost:8000/optimize",
+        "http://localhost:8000/research/stream",
+    ]
+
+
 def test_post_json_warns_and_logs_when_falling_back(monkeypatch) -> None:
     """POST helper should warn and print that the UI is using a mock response."""
     warnings: list[str] = []

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -8,6 +8,8 @@ import requests
 
 from apps.dashboard.api_client import (
     build_optimize_payload,
+    calculate_period_return_metrics,
+    explain_reasoning_rows,
     extract_risk_signals_from_research_event,
     extract_risk_tags_from_research_event,
     format_research_log_event,
@@ -166,6 +168,73 @@ def test_build_optimize_payload_includes_session_risk_tags() -> None:
         "risk_tags": ["equity_market_risk", "geopolitical_fx_risk"],
         "risk_signals": [],
     }
+
+
+def test_calculate_period_return_metrics_rebases_cumulative_series() -> None:
+    """Dashboard period metrics should compare returns within the selected slice."""
+    cumulative_return, excess_return = calculate_period_return_metrics(
+        [2.0, 3.0],
+        [5.0, 6.0],
+    )
+
+    assert cumulative_return == 0.5
+    assert round(excess_return, 10) == 0.3
+
+
+def test_explain_reasoning_rows_includes_global_and_feature_context() -> None:
+    """Dashboard should render both response-level and per-feature SHAP reasoning."""
+    rows = explain_reasoning_rows(
+        {
+            "reasoning_context": [
+                {
+                    "event_date": "2024-12-30",
+                    "tag": "equity_market_risk",
+                    "severity": 0.66,
+                    "decayed_score": 0.5,
+                    "reasoning": "시장 급락",
+                    "source": "gdelt",
+                }
+            ],
+            "feature_contributions": [
+                {
+                    "feature": "risk_equity_market_risk",
+                    "reasoning_context": [
+                        {
+                            "event_date": "2024-12-30",
+                            "tag": "equity_market_risk",
+                            "severity": 0.66,
+                            "decayed_score": 0.5,
+                            "reasoning": "시장 급락",
+                            "source": "gdelt",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert rows == [
+        {
+            "구분": "전체",
+            "피처": "",
+            "날짜": "2024-12-30",
+            "태그": "equity_market_risk",
+            "강도": 0.66,
+            "감쇠점수": 0.5,
+            "근거": "시장 급락",
+            "출처": "gdelt",
+        },
+        {
+            "구분": "피처",
+            "피처": "risk_equity_market_risk",
+            "날짜": "2024-12-30",
+            "태그": "equity_market_risk",
+            "강도": 0.66,
+            "감쇠점수": 0.5,
+            "근거": "시장 급락",
+            "출처": "gdelt",
+        },
+    ]
 
 
 def test_extract_risk_signals_from_research_event_filters_schema() -> None:

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -1,0 +1,85 @@
+"""Dashboard page behavior tests."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from datetime import datetime
+
+if "streamlit_echarts" not in sys.modules:
+    stub = ModuleType("streamlit_echarts")
+    stub.JsCode = lambda value: value
+    stub.st_echarts = lambda *args, **kwargs: None
+    sys.modules["streamlit_echarts"] = stub
+
+import apps.dashboard.app as dashboard_app
+
+
+def test_mock_optimize_matches_api_shape_and_is_stable() -> None:
+    """Fallback optimize data should look like a real API response and be deterministic."""
+    first = dashboard_app._mock_optimize(1.5)
+    second = dashboard_app._mock_optimize(1.5)
+
+    assert first == second
+    assert first["status"] == "mock"
+    assert isinstance(first["message"], str) and first["message"]
+    assert isinstance(first["elapsed_ms"], float)
+    assert first["elapsed_ms"] == 0.0
+    assert first["timed_out"] is False
+    assert isinstance(first["tickers"], list) and first["tickers"]
+    assert set(first["weights"]) == set(first["tickers"])
+    assert isinstance(first["expected_return"], float)
+    assert isinstance(first["expected_volatility"], float)
+    assert set(first["returns"]) == {"date", "portfolio", "benchmark"}
+
+
+def test_portfolio_data_cache_survives_rerun(monkeypatch) -> None:
+    """Portfolio page should reuse the last successful optimize response across reruns."""
+    state: dict[str, object] = {}
+    monkeypatch.setattr(dashboard_app.st, "session_state", state)
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_post(endpoint: str, payload: dict, timeout: int = 10) -> dict:
+        calls.append((endpoint, payload))
+        return {
+            "status": "ready",
+            "message": "real response",
+            "elapsed_ms": 12.3,
+            "timed_out": False,
+            "tickers": ["SPY", "QQQ"],
+            "weights": {"SPY": 0.6, "QQQ": 0.4},
+            "risk_profile": "balanced",
+            "expected_return": 0.084,
+            "expected_volatility": 0.132,
+            "returns": {
+                "date": ["2024-01-01", "2024-01-02"],
+                "portfolio": [1.0, 1.02],
+                "benchmark": [1.0, 1.01],
+            },
+        }
+
+    monkeypatch.setattr(dashboard_app, "_post", fake_post)
+
+    first = dashboard_app._ensure_portfolio_data(1.5, ["equity_market_risk"], [], refresh=True)
+    second = dashboard_app._ensure_portfolio_data(2.0, [], [], refresh=False)
+
+    assert first == second
+    assert calls == [
+        (
+            "/optimize",
+            {
+                "risk_aversion": 1.5,
+                "risk_tags": ["equity_market_risk"],
+                "risk_signals": [],
+            },
+        )
+    ]
+    assert state["portfolio_data"] == first
+    assert state["portfolio_payload"] == {
+        "risk_aversion": 1.5,
+        "risk_tags": ["equity_market_risk"],
+        "risk_signals": [],
+    }
+    assert isinstance(state["portfolio_updated_at"], str)
+    datetime.strptime(state["portfolio_updated_at"], "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- Normalize dashboard API base URLs so client calls consistently target the expected endpoint paths.
- Improve portfolio optimization response handling in the dashboard app.
- Add focused regression tests for dashboard API client behavior and portfolio optimization handling.

## Impact
This makes dashboard API calls more robust across URL configurations and keeps portfolio optimization UI behavior covered by tests.

## Validation
- `.venv/bin/python -m pytest tests/test_dashboard_api_client.py tests/test_dashboard_app.py`