### PR TITLE
fix : 대시보드 리스크/ANOVA 검증 표시 개선

### DIFF
--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -228,6 +228,81 @@ def build_optimize_payload(
     }
 
 
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _anova_significance_label(p_value: float | None) -> str:
+    if p_value is None:
+        return "계산값 없음"
+    return "유의함" if p_value < 0.05 else "유의하지 않음"
+
+
+def anova_summary_rows(anova_list: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Flatten computed ANOVA results into dashboard summary rows."""
+    labels = {
+        "reward_function_comparison": ("검증 1", "보상 함수 비교", "One-way"),
+        "strategy_comparison": ("검증 2", "전략 비교", "One-way"),
+        "market_regime_comparison": ("검증 3", "국면 주효과", "Two-way"),
+    }
+    rows: list[dict[str, Any]] = []
+    for item in anova_list or []:
+        if not isinstance(item, dict):
+            continue
+        check, effect, method = labels.get(
+            str(item.get("name") or ""),
+            (str(item.get("name") or "ANOVA"), "주효과", "ANOVA"),
+        )
+        f_statistic = _float_or_none(item.get("f_statistic"))
+        p_value = _float_or_none(item.get("p_value"))
+        rows.append(
+            {
+                "검증": check,
+                "효과": effect,
+                "방법": method,
+                "F 통계량": f_statistic,
+                "p-value": p_value,
+                "η²": _float_or_none(item.get("eta_squared")),
+                "판정": _anova_significance_label(p_value),
+            }
+        )
+
+        if str(item.get("name") or "") != "market_regime_comparison":
+            continue
+        strategy_effect = item.get("strategy_effect") or {}
+        if isinstance(strategy_effect, dict):
+            strategy_p = _float_or_none(strategy_effect.get("p_value"))
+            rows.append(
+                {
+                    "검증": check,
+                    "효과": "전략 주효과",
+                    "방법": method,
+                    "F 통계량": _float_or_none(strategy_effect.get("f_statistic")),
+                    "p-value": strategy_p,
+                    "η²": None,
+                    "판정": _anova_significance_label(strategy_p),
+                }
+            )
+        interaction = item.get("interaction") or {}
+        if isinstance(interaction, dict):
+            interaction_p = _float_or_none(interaction.get("p_value"))
+            rows.append(
+                {
+                    "검증": check,
+                    "효과": "국면 × 전략 교호작용",
+                    "방법": method,
+                    "F 통계량": _float_or_none(interaction.get("f_statistic")),
+                    "p-value": interaction_p,
+                    "η²": None,
+                    "판정": _anova_significance_label(interaction_p),
+                }
+            )
+    return rows
+
+
 def get_json(
     base_url: str,
     endpoint: str,

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -241,6 +241,77 @@ def _anova_significance_label(p_value: float | None) -> str:
     return "유의함" if p_value < 0.05 else "유의하지 않음"
 
 
+def _is_significant(p_value: Any) -> bool:
+    numeric = _float_or_none(p_value)
+    return numeric is not None and numeric < 0.05
+
+
+def _anova_item_by_name(anova_list: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    return next((item for item in anova_list if item.get("name") == name), {})
+
+
+def _anova_row_interpretation(effect: str, p_value: float | None) -> str:
+    significant = p_value is not None and p_value < 0.05
+    if effect == "보상 함수 비교":
+        return "보상 함수별 성과 차이 확인" if significant else "효과 크기와 비유의 원인 해석 필요"
+    if effect == "전략 비교":
+        return "전략 간 성과 차이 확인" if significant else "효과 크기와 비유의 원인 해석 필요"
+    if effect == "국면 주효과":
+        return "시장 국면별 성과 차이 확인" if significant else "효과 크기와 비유의 원인 해석 필요"
+    if effect == "전략 주효과":
+        return "전략 자체의 성과 차이 확인" if significant else "효과 크기와 비유의 원인 해석 필요"
+    if effect == "국면 × 전략 교호작용":
+        return "국면별 전략 우위 변화 확인" if significant else "전략 우위 일관성 확인"
+    return "계산 결과 확인"
+
+
+def anova_attainment_cards(anova_list: list[dict[str, Any]] | None) -> list[dict[str, str]]:
+    """Summarize whether the ANOVA reporting rubric is satisfied."""
+    rows = [item for item in anova_list or [] if isinstance(item, dict)]
+    reward = _anova_item_by_name(rows, "reward_function_comparison")
+    strategy = _anova_item_by_name(rows, "strategy_comparison")
+    regime = _anova_item_by_name(rows, "market_regime_comparison")
+    strategy_effect = regime.get("strategy_effect") or {}
+    interaction = regime.get("interaction") or {}
+
+    required = [reward, strategy, regime]
+    reporting_complete = all(
+        item
+        and _float_or_none(item.get("p_value")) is not None
+        and _float_or_none(item.get("eta_squared")) is not None
+        and isinstance(item.get("post_hoc"), list)
+        for item in required
+    )
+    main_effects_significant = all(
+        [
+            _is_significant(reward.get("p_value")),
+            _is_significant(strategy.get("p_value")),
+            _is_significant(regime.get("p_value")),
+            isinstance(strategy_effect, dict) and _is_significant(strategy_effect.get("p_value")),
+        ]
+    )
+    interaction_p = _float_or_none(interaction.get("p_value") if isinstance(interaction, dict) else None)
+    interaction_consistent = interaction_p is not None and interaction_p >= 0.05
+
+    return [
+        {
+            "label": "보고 완성도",
+            "status": "달성" if reporting_complete else "점검 필요",
+            "detail": "p-value, η², 사후검정/비유의 해석 항목 보고",
+        },
+        {
+            "label": "주요 효과 유의성",
+            "status": "달성" if main_effects_significant else "해석 필요",
+            "detail": "보상 함수, 전략, 국면, 전략 주효과 p < 0.05 기준",
+        },
+        {
+            "label": "교호작용 해석",
+            "status": "일관성 확인" if interaction_consistent else "국면별 차이 확인",
+            "detail": "비유의이면 전략 우위가 국면별로 크게 뒤집히지 않음",
+        },
+    ]
+
+
 def anova_summary_rows(anova_list: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
     """Flatten computed ANOVA results into dashboard summary rows."""
     labels = {
@@ -267,6 +338,7 @@ def anova_summary_rows(anova_list: list[dict[str, Any]] | None) -> list[dict[str
                 "p-value": p_value,
                 "η²": _float_or_none(item.get("eta_squared")),
                 "판정": _anova_significance_label(p_value),
+                "해석": _anova_row_interpretation(effect, p_value),
             }
         )
 
@@ -284,6 +356,7 @@ def anova_summary_rows(anova_list: list[dict[str, Any]] | None) -> list[dict[str
                     "p-value": strategy_p,
                     "η²": None,
                     "판정": _anova_significance_label(strategy_p),
+                    "해석": _anova_row_interpretation("전략 주효과", strategy_p),
                 }
             )
         interaction = item.get("interaction") or {}
@@ -298,9 +371,39 @@ def anova_summary_rows(anova_list: list[dict[str, Any]] | None) -> list[dict[str
                     "p-value": interaction_p,
                     "η²": None,
                     "판정": _anova_significance_label(interaction_p),
+                    "해석": _anova_row_interpretation("국면 × 전략 교호작용", interaction_p),
                 }
             )
     return rows
+
+
+def post_hoc_group_options(post_hoc: list[dict[str, Any]] | None) -> list[str]:
+    """Return group filter options from computed Tukey HSD rows."""
+    groups: set[str] = set()
+    for row in post_hoc or []:
+        if not isinstance(row, dict):
+            continue
+        for key in ("group1", "group2"):
+            value = str(row.get(key) or "")
+            if value:
+                groups.add(value)
+    return sorted(groups)
+
+
+def filter_post_hoc_rows(
+    post_hoc: list[dict[str, Any]] | None,
+    selected_groups: list[str] | None,
+) -> list[dict[str, Any]]:
+    """Filter Tukey HSD rows by selected groups, preserving all rows when empty."""
+    rows = [row for row in post_hoc or [] if isinstance(row, dict)]
+    selected = set(selected_groups or [])
+    if not selected:
+        return rows
+    return [
+        row
+        for row in rows
+        if str(row.get("group1") or "") in selected or str(row.get("group2") or "") in selected
+    ]
 
 
 def get_json(

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -190,6 +190,31 @@ def risk_vector_from_tags(risk_tags: list[str] | None) -> list[float]:
     return [1.0 if tag in selected else 0.0 for tag in RL_RISK_TAGS]
 
 
+def risk_vector_from_signals(
+    risk_signals: list[dict[str, Any]] | None,
+    fallback_tags: list[str] | None = None,
+) -> list[float]:
+    """Build the dashboard display vector from severity-bearing risk signals."""
+    severity_by_tag: dict[str, float] = {}
+    for item in risk_signals or []:
+        if not isinstance(item, dict):
+            continue
+        tag = str(item.get("tag") or "")
+        if tag not in RL_RISK_TAGS:
+            continue
+        try:
+            severity = float(item.get("severity", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= severity <= 1.0:
+            severity_by_tag[tag] = severity
+
+    if not severity_by_tag:
+        return risk_vector_from_tags(fallback_tags)
+
+    return [severity_by_tag.get(tag, 0.0) for tag in RL_RISK_TAGS]
+
+
 def build_optimize_payload(
     risk_aversion: float,
     risk_tags: list[str] | None = None,

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -25,6 +25,7 @@ try:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        anova_summary_rows,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -40,6 +41,7 @@ except ModuleNotFoundError:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        anova_summary_rows,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -971,6 +973,14 @@ def anova_page() -> None:
         bt5 = _get("/backtest") or _mock_backtest()
 
     anova_list: list = bt5.get("anova", _mock_backtest()["anova"])
+    summary_rows = anova_summary_rows(anova_list)
+    if summary_rows:
+        st.markdown("**계산된 ANOVA 요약**")
+        st.dataframe(
+            pd.DataFrame(summary_rows),
+            hide_index=True,
+            use_container_width=True,
+        )
 
     _EXP_LABELS = {
         "reward_function_comparison": "검증 1 — 보상함수 비교",

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -25,11 +25,14 @@ try:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        anova_attainment_cards,
         anova_summary_rows,
         extract_risk_context_from_research_event,
+        filter_post_hoc_rows,
         format_research_log_event,
         get_json,
         post_json,
+        post_hoc_group_options,
         research_result_from_event,
         risk_vector_from_signals,
         stream_ndjson,
@@ -41,11 +44,14 @@ except ModuleNotFoundError:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        anova_attainment_cards,
         anova_summary_rows,
         extract_risk_context_from_research_event,
+        filter_post_hoc_rows,
         format_research_log_event,
         get_json,
         post_json,
+        post_hoc_group_options,
         research_result_from_event,
         risk_vector_from_signals,
         stream_ndjson,
@@ -961,18 +967,20 @@ def anova_page() -> None:
     with st.sidebar:
         st.divider()
         st.subheader(":material/tune: 분석 설정")
-        strategies: list[str] = st.multiselect(
-            "비교 전략",
-            ["PPO", "MVO", "동일비중"],
-            default=["PPO"],
-            help="사후 검정 결과 필터",
-        )
+        st.caption("사후 검정 필터는 각 검증 탭에서 실제 계산 그룹 기준으로 선택합니다.")
 
     st.title("ANOVA 검증 결과")
     with st.spinner("GET /backtest 호출 중…"):
         bt5 = _get("/backtest") or _mock_backtest()
 
     anova_list: list = bt5.get("anova", _mock_backtest()["anova"])
+    cards = anova_attainment_cards(anova_list)
+    if cards:
+        card_cols = st.columns(len(cards))
+        for col, card in zip(card_cols, cards):
+            col.metric(card["label"], card["status"], border=True)
+            col.caption(card["detail"])
+
     summary_rows = anova_summary_rows(anova_list)
     if summary_rows:
         st.markdown("**계산된 ANOVA 요약**")
@@ -987,11 +995,17 @@ def anova_page() -> None:
         "strategy_comparison": "검증 2 — 전략 비교",
         "market_regime_comparison": "검증 3 — 국면 × 전략 (Two-way)",
     }
+    _EXP_PURPOSES = {
+        "reward_function_comparison": "목적: reward 함수 선택이 성과 차이를 만드는지 검증합니다.",
+        "strategy_comparison": "목적: PPO, MVO, 동일가중 전략 간 성과 차이를 검증합니다.",
+        "market_regime_comparison": "목적: 시장 국면과 전략의 효과를 분리하고 교호작용을 검증합니다.",
+    }
     tab_labels = [_EXP_LABELS.get(a.get("name", ""), a.get("name", "")) for a in anova_list]
     tabs = st.tabs(tab_labels) if tab_labels else []
 
     for tab, anova in zip(tabs, anova_list):
         with tab:
+            st.caption(_EXP_PURPOSES.get(anova.get("name", ""), "목적: 계산된 ANOVA 결과를 확인합니다."))
             a1, a2, a3 = st.columns(3)
             a1.metric("F 통계량", f"{anova.get('f_statistic', 0):.2f}", border=True)
             a2.metric("p-value", f"{anova.get('p_value', 1):.4f}", border=True)
@@ -1007,7 +1021,9 @@ def anova_page() -> None:
             if interaction:
                 sig = interaction.get("significant", False)
                 label = (
-                    "✅ 교호작용 유의 (전략 효과가 국면에 따라 다름)" if sig else "교호작용 비유의"
+                    "교호작용 유의: 전략 효과가 국면에 따라 달라짐"
+                    if sig
+                    else "교호작용 비유의: 전략 우위가 국면별로 크게 뒤집히지 않음"
                 )
                 st.info(
                     f"**교호작용** — F={interaction.get('f_statistic', 0):.2f}, "
@@ -1022,15 +1038,15 @@ def anova_page() -> None:
             with st.container(border=True):
                 st.markdown("**사후 검정 결과 (Tukey HSD)**")
                 posthoc_all = anova.get("post_hoc", [])
-                posthoc = (
-                    [
-                        row
-                        for row in posthoc_all
-                        if row["group1"] in strategies or row["group2"] in strategies
-                    ]
-                    if strategies
-                    else posthoc_all
+                group_options = post_hoc_group_options(posthoc_all)
+                selected_groups = st.multiselect(
+                    "집단 필터",
+                    group_options,
+                    default=[],
+                    key=f"posthoc_filter_{anova.get('name', '')}",
+                    help="선택하지 않으면 전체 사후 검정 결과를 표시합니다.",
                 )
+                posthoc = filter_post_hoc_rows(posthoc_all, selected_groups)
 
                 if posthoc:
                     ph = pd.DataFrame(posthoc)

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -30,7 +30,7 @@ try:
         get_json,
         post_json,
         research_result_from_event,
-        risk_vector_from_tags,
+        risk_vector_from_signals,
         stream_ndjson,
     )
 except ModuleNotFoundError:
@@ -45,7 +45,7 @@ except ModuleNotFoundError:
         get_json,
         post_json,
         research_result_from_event,
-        risk_vector_from_tags,
+        risk_vector_from_signals,
         stream_ndjson,
     )
 
@@ -494,6 +494,7 @@ def _render_research_result(result: dict[str, Any] | None) -> None:
         return
 
     tags = result.get("risk_tags", [])
+    signals = result.get("risk_signals", [])
     updated_at = st.session_state.get("risk_tags_updated_at")
 
     with st.container(border=True):
@@ -517,7 +518,7 @@ def _render_research_result(result: dict[str, Any] | None) -> None:
             f"최근 리서치 태그: {', '.join(tags) if tags else '없음'}"
             + (f" | 저장 시각: {updated_at}" if updated_at else "")
         )
-        st.caption(f"RL 관측 벡터 {RL_RISK_TAGS}: {risk_vector_from_tags(tags)}")
+        st.caption(f"RL 관측 벡터 {RL_RISK_TAGS}: {risk_vector_from_signals(signals, tags)}")
 
 
 # ─────────────────────────────────────────────
@@ -1048,12 +1049,13 @@ def risk_page() -> None:
 
     st.title("리스크 모니터링")
     current_risk_tags = st.session_state.get("risk_tags", [])
-    risk_vector = risk_vector_from_tags(current_risk_tags)
+    current_risk_signals = st.session_state.get("risk_signals", [])
+    risk_vector = risk_vector_from_signals(current_risk_signals, current_risk_tags)
 
     st.markdown("**리서치 기반 RL 리스크 관측 벡터**")
     tag_cols = st.columns(3)
     for col, tag, value in zip(tag_cols, RL_RISK_TAGS, risk_vector):
-        col.metric(tag, "감지" if value else "미감지", border=True)
+        col.metric(tag, f"{value:.2f}", border=True)
     st.caption(f"관측 벡터 순서 {RL_RISK_TAGS}: {risk_vector}")
 
     with st.spinner("GET /backtest 호출 중…"):

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -17,3 +17,4 @@ langchain-core==1.2.27
 langgraph==1.1.6
 scipy>=1.12.0
 statsmodels>=0.14.0
+protobuf==3.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ streamlit-echarts~=0.6.0
 
 # 거래일 캘린더 (market_close.py)
 pandas_market_calendars>=4.4
+
+protobuf==3.20.3

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -7,15 +7,18 @@ from typing import Any
 import requests
 
 from apps.dashboard.api_client import (
+    anova_attainment_cards,
     anova_summary_rows,
     build_optimize_payload,
     calculate_period_return_metrics,
     explain_reasoning_rows,
+    filter_post_hoc_rows,
     extract_risk_signals_from_research_event,
     extract_risk_tags_from_research_event,
     format_research_log_event,
     get_json,
     post_json,
+    post_hoc_group_options,
     research_result_from_event,
     risk_vector_from_signals,
     risk_vector_from_tags,
@@ -291,6 +294,7 @@ def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() ->
             "p-value": 0.123,
             "η²": 0.11,
             "판정": "유의하지 않음",
+            "해석": "효과 크기와 비유의 원인 해석 필요",
         },
         {
             "검증": "검증 2",
@@ -300,6 +304,7 @@ def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() ->
             "p-value": 0.004,
             "η²": 0.22,
             "판정": "유의함",
+            "해석": "전략 간 성과 차이 확인",
         },
         {
             "검증": "검증 3",
@@ -309,6 +314,7 @@ def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() ->
             "p-value": 0.001,
             "η²": 0.33,
             "판정": "유의함",
+            "해석": "시장 국면별 성과 차이 확인",
         },
         {
             "검증": "검증 3",
@@ -318,6 +324,7 @@ def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() ->
             "p-value": 0.0001,
             "η²": None,
             "판정": "유의함",
+            "해석": "전략 자체의 성과 차이 확인",
         },
         {
             "검증": "검증 3",
@@ -327,8 +334,57 @@ def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() ->
             "p-value": 0.456,
             "η²": None,
             "판정": "유의하지 않음",
+            "해석": "전략 우위 일관성 확인",
         },
     ]
+
+
+def test_anova_attainment_cards_reflect_rubric_from_computed_values() -> None:
+    """Dashboard cards should describe ANOVA rubric status from computed values."""
+    cards = anova_attainment_cards(
+        [
+            {"name": "reward_function_comparison", "p_value": 0.001, "eta_squared": 0.1, "post_hoc": []},
+            {"name": "strategy_comparison", "p_value": 0.002, "eta_squared": 0.2, "post_hoc": []},
+            {
+                "name": "market_regime_comparison",
+                "p_value": 0.003,
+                "eta_squared": 0.3,
+                "post_hoc": [],
+                "strategy_effect": {"p_value": 0.004},
+                "interaction": {"p_value": 0.9},
+            },
+        ]
+    )
+
+    assert cards == [
+        {
+            "label": "보고 완성도",
+            "status": "달성",
+            "detail": "p-value, η², 사후검정/비유의 해석 항목 보고",
+        },
+        {
+            "label": "주요 효과 유의성",
+            "status": "달성",
+            "detail": "보상 함수, 전략, 국면, 전략 주효과 p < 0.05 기준",
+        },
+        {
+            "label": "교호작용 해석",
+            "status": "일관성 확인",
+            "detail": "비유의이면 전략 우위가 국면별로 크게 뒤집히지 않음",
+        },
+    ]
+
+
+def test_post_hoc_filter_uses_actual_group_names() -> None:
+    """Post-hoc filters should come from Tukey rows, not fixed strategy names."""
+    rows = [
+        {"group1": "PPO-return", "group2": "PPO-sharpe"},
+        {"group1": "PPO-mdd", "group2": "PPO-return"},
+    ]
+
+    assert post_hoc_group_options(rows) == ["PPO-mdd", "PPO-return", "PPO-sharpe"]
+    assert filter_post_hoc_rows(rows, []) == rows
+    assert filter_post_hoc_rows(rows, ["PPO-sharpe"]) == [rows[0]]
 
 
 def test_explain_reasoning_rows_includes_global_and_feature_context() -> None:

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -16,6 +16,7 @@ from apps.dashboard.api_client import (
     get_json,
     post_json,
     research_result_from_event,
+    risk_vector_from_signals,
     risk_vector_from_tags,
     stream_ndjson,
 )
@@ -178,6 +179,21 @@ def test_research_complete_event_extracts_rl_risk_tags() -> None:
 
     assert extract_risk_tags_from_research_event(event) == ["equity_market_risk", "geopolitical_fx_risk", "macro_rate_risk"]
     assert risk_vector_from_tags(["equity_market_risk", "geopolitical_fx_risk"]) == [0.0, 1.0, 1.0]
+
+
+def test_risk_vector_from_signals_uses_severity_values() -> None:
+    """Dashboard display vector should preserve risk signal severity."""
+    signals = [
+        {"tag": "equity_market_risk", "severity": 0.66},
+        {"tag": "geopolitical_fx_risk", "severity": 0.33},
+    ]
+
+    assert risk_vector_from_signals(signals, ["macro_rate_risk"]) == [0.0, 0.66, 0.33]
+
+
+def test_risk_vector_from_signals_falls_back_to_tags_when_empty() -> None:
+    """Dashboard display vector should remain compatible with tag-only events."""
+    assert risk_vector_from_signals([], ["macro_rate_risk"]) == [1.0, 0.0, 0.0]
 
 
 def test_research_result_from_complete_event() -> None:

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -7,6 +7,7 @@ from typing import Any
 import requests
 
 from apps.dashboard.api_client import (
+    anova_summary_rows,
     build_optimize_payload,
     calculate_period_return_metrics,
     explain_reasoning_rows,
@@ -249,6 +250,85 @@ def test_calculate_period_return_metrics_rebases_cumulative_series() -> None:
 
     assert cumulative_return == 0.5
     assert round(excess_return, 10) == 0.3
+
+
+def test_anova_summary_rows_flattens_computed_values_without_fixed_outcomes() -> None:
+    """Dashboard should render ANOVA rows from the computed API payload."""
+    rows = anova_summary_rows(
+        [
+            {
+                "name": "reward_function_comparison",
+                "f_statistic": 1.23,
+                "p_value": 0.123,
+                "eta_squared": 0.11,
+                "post_hoc": [],
+            },
+            {
+                "name": "strategy_comparison",
+                "f_statistic": 4.56,
+                "p_value": 0.004,
+                "eta_squared": 0.22,
+                "post_hoc": [],
+            },
+            {
+                "name": "market_regime_comparison",
+                "f_statistic": 7.89,
+                "p_value": 0.001,
+                "eta_squared": 0.33,
+                "post_hoc": [],
+                "strategy_effect": {"f_statistic": 8.76, "p_value": 0.0001},
+                "interaction": {"f_statistic": 0.12, "p_value": 0.456, "significant": False},
+            },
+        ]
+    )
+
+    assert rows == [
+        {
+            "검증": "검증 1",
+            "효과": "보상 함수 비교",
+            "방법": "One-way",
+            "F 통계량": 1.23,
+            "p-value": 0.123,
+            "η²": 0.11,
+            "판정": "유의하지 않음",
+        },
+        {
+            "검증": "검증 2",
+            "효과": "전략 비교",
+            "방법": "One-way",
+            "F 통계량": 4.56,
+            "p-value": 0.004,
+            "η²": 0.22,
+            "판정": "유의함",
+        },
+        {
+            "검증": "검증 3",
+            "효과": "국면 주효과",
+            "방법": "Two-way",
+            "F 통계량": 7.89,
+            "p-value": 0.001,
+            "η²": 0.33,
+            "판정": "유의함",
+        },
+        {
+            "검증": "검증 3",
+            "효과": "전략 주효과",
+            "방법": "Two-way",
+            "F 통계량": 8.76,
+            "p-value": 0.0001,
+            "η²": None,
+            "판정": "유의함",
+        },
+        {
+            "검증": "검증 3",
+            "효과": "국면 × 전략 교호작용",
+            "방법": "Two-way",
+            "F 통계량": 0.12,
+            "p-value": 0.456,
+            "η²": None,
+            "판정": "유의하지 않음",
+        },
+    ]
 
 
 def test_explain_reasoning_rows_includes_global_and_feature_context() -> None:


### PR DESCRIPTION
## 요약

대시보드에서 리서치 리스크 강도와 ANOVA 검증 달성 여부가 실제 계산값 기준으로 명확히 보이도록 개선했습니다.

## 주요 변경 사항

- 리서치 결과의 `risk_signals.severity`를 사용해 RL 리스크 관측 벡터를 0/1이 아닌 0.0~1.0 강도로 표시합니다.
- ANOVA 탭 상단에 성능 기준 달성 여부 카드 3종을 추가했습니다.
  - 보고 완성도
  - 주요 효과 유의성
  - 교호작용 해석
- `/backtest`에서 계산된 ANOVA 결과를 기반으로 요약 표를 구성합니다.
  - 보상 함수 비교
  - 전략 비교
  - 시장 국면 주효과
  - 전략 주효과
  - 국면 × 전략 교호작용
- 교호작용 비유의를 실패처럼 보이지 않게 `전략 우위 일관성 확인`으로 해석합니다.
- Tukey HSD 사후검정 필터를 고정 전략명이 아니라 실제 계산된 `group1/group2` 값에서 동적으로 생성합니다.
- ChromaDB 실행 시 발생한 protobuf 호환성 문제를 막기 위해 requirements에 protobuf 3.20.x 제약을 추가했습니다.

## 검증

- [x] `.venv/bin/python -m pytest tests/test_dashboard_api_client.py -q`
- [x] 로컬 `build_backtest_response()`로 실제 ANOVA 계산값 확인

## 참고

- 이 PR은 ANOVA 값을 하드코딩하지 않고, API의 `/backtest` 응답에 포함된 계산 결과를 대시보드 표시용 행/카드로 변환합니다.
- 현재 로컬 작업트리에는 이 PR 범위 밖의 `docs/chroma_pipeline.md` 수정이 남아 있으며, PR에는 포함하지 않았습니다.