### PR TITLE
[fix] stream analyst research tokens

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for the FastAPI backend."""
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -124,6 +124,7 @@ class ResearchResponse(BaseModel):
     status: EndpointStatus
     elapsed_ms: float = 0.0
     timed_out: bool = False
+    timings: dict[str, Any] = Field(default_factory=dict)
     question: str
     report: str
     sources: list[str]

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -338,18 +338,21 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
         return
 
     final_state: dict[str, Any] | None = None
-    node_starts: dict[str, float] = {}
+    run_starts: dict[str, tuple[str, float]] = {}
     timings: dict[str, float] = {}
     try:
         async for event in stream_graph_events(question):
             elapsed_ms = _elapsed_ms(start)
             node = _graph_event_node(event)
+            timing_key = _graph_event_timing_key(event)
+            run_id = str(event.get("run_id") or f"{timing_key}:{event.get('event')}")
             duration_ms = None
             if event.get("event") in {"on_chain_start", "on_tool_start"}:
-                node_starts[node] = perf_counter()
-            elif event.get("event") in {"on_chain_end", "on_tool_end"} and node in node_starts:
-                duration_ms = round((perf_counter() - node_starts.pop(node)) * 1000, 2)
-                timings[f"{node}_ms"] = duration_ms
+                run_starts[run_id] = (timing_key, perf_counter())
+            elif event.get("event") in {"on_chain_end", "on_tool_end"} and run_id in run_starts:
+                started_key, started_at = run_starts.pop(run_id)
+                duration_ms = round((perf_counter() - started_at) * 1000, 2)
+                timings[f"{started_key}_ms"] = duration_ms
 
             event_state = _state_from_graph_event(event)
             if event_state:
@@ -436,6 +439,14 @@ def _graph_event_node(event: dict[str, Any]) -> str:
     if isinstance(metadata, dict) and metadata.get("langgraph_node"):
         return str(metadata["langgraph_node"])
     return str(event.get("name") or "research")
+
+
+def _graph_event_timing_key(event: dict[str, Any]) -> str:
+    """Return the timing bucket for a LangGraph stream event."""
+    name = str(event.get("name") or "")
+    if name == "route_after_grade":
+        return name
+    return _graph_event_node(event)
 
 
 def _compact_graph_event(

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -560,7 +560,7 @@ def _research_response_from_state(question: str, state: dict[str, Any]) -> Resea
         reasoning_trace=reasoning_trace,
         risk_tags=risk_tags,
         risk_signals=risk_signals,
-        timings={str(key): value for key, value in timings.items()},
+        timings=timings,
     )
 
 

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -338,12 +338,23 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
         return
 
     final_state: dict[str, Any] | None = None
+    node_starts: dict[str, float] = {}
+    timings: dict[str, float] = {}
     try:
         async for event in stream_graph_events(question):
+            elapsed_ms = _elapsed_ms(start)
+            node = _graph_event_node(event)
+            duration_ms = None
+            if event.get("event") in {"on_chain_start", "on_tool_start"}:
+                node_starts[node] = perf_counter()
+            elif event.get("event") in {"on_chain_end", "on_tool_end"} and node in node_starts:
+                duration_ms = round((perf_counter() - node_starts.pop(node)) * 1000, 2)
+                timings[f"{node}_ms"] = duration_ms
+
             event_state = _state_from_graph_event(event)
             if event_state:
                 final_state = {**(final_state or {}), **event_state}
-            compact = _compact_graph_event(event)
+            compact = _compact_graph_event(event, elapsed_ms=elapsed_ms, duration_ms=duration_ms)
             if compact:
                 yield _to_ndjson(compact)
     except Exception as exc:
@@ -371,7 +382,9 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
         )
         return
 
-    response = _research_response_from_state(question, final_state or {})
+    total_ms = _elapsed_ms(start)
+    timings["total_ms"] = total_ms
+    response = _research_response_from_state(question, {**(final_state or {}), "timings": timings})
     log_e2e_event(
         "/research/stream",
         status=response.status,
@@ -391,6 +404,7 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
             "reasoning_trace": response.reasoning_trace,
             "risk_tags": response.risk_tags,
             "risk_signals": [signal.model_dump() for signal in response.risk_signals],
+            "timings": response.timings,
         }
     )
 
@@ -410,19 +424,33 @@ def _state_from_graph_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "risk_tags",
         "rl_risk_tags",
         "risk_signals",
+        "timings",
     }
     if not any(key in output for key in useful_keys):
         return None
     return {str(key): value for key, value in output.items() if key in useful_keys}
 
 
-def _compact_graph_event(event: dict[str, Any]) -> dict[str, Any] | None:
+def _graph_event_node(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    if isinstance(metadata, dict) and metadata.get("langgraph_node"):
+        return str(metadata["langgraph_node"])
+    return str(event.get("name") or "research")
+
+
+def _compact_graph_event(
+    event: dict[str, Any],
+    *,
+    elapsed_ms: float | None = None,
+    duration_ms: float | None = None,
+) -> dict[str, Any] | None:
     """Convert LangGraph events to small dashboard-oriented NDJSON payloads."""
     event_type = str(event.get("event", "event"))
     if event_type not in _STREAM_EVENT_ALLOWLIST:
         return None
 
     name = str(event.get("name") or "research")
+    node = _graph_event_node(event)
     data = event.get("data") or {}
     text = ""
     if isinstance(data, dict):
@@ -435,7 +463,12 @@ def _compact_graph_event(event: dict[str, Any]) -> dict[str, Any] | None:
 
     if event_type == "on_chat_model_stream" and not text:
         return None
-    return {"type": event_type, "name": name, "text": text[:500]}
+    compact = {"type": event_type, "name": name, "node": node, "text": text[:500]}
+    if elapsed_ms is not None:
+        compact["elapsed_ms"] = elapsed_ms
+    if duration_ms is not None:
+        compact["duration_ms"] = duration_ms
+    return compact
 
 
 def _compact_event_text(value: Any) -> str:
@@ -494,6 +527,7 @@ def _research_response_from_state(question: str, state: dict[str, Any]) -> Resea
         risk_tags
     )
     sources = [str(source) for source in state.get("sources", []) if source]
+    timings = state.get("timings") if isinstance(state.get("timings"), dict) else {}
 
     return ResearchResponse(
         status="ready",
@@ -503,6 +537,7 @@ def _research_response_from_state(question: str, state: dict[str, Any]) -> Resea
         reasoning_trace=reasoning_trace,
         risk_tags=risk_tags,
         risk_signals=risk_signals,
+        timings={str(key): value for key, value in timings.items()},
     )
 
 

--- a/apps/api/services.py
+++ b/apps/api/services.py
@@ -343,16 +343,15 @@ async def stream_research_response(question: str) -> AsyncIterator[str]:
     try:
         async for event in stream_graph_events(question):
             elapsed_ms = _elapsed_ms(start)
-            node = _graph_event_node(event)
             timing_key = _graph_event_timing_key(event)
-            run_id = str(event.get("run_id") or f"{timing_key}:{event.get('event')}")
+            run_id = str(event.get("run_id") or timing_key)
             duration_ms = None
             if event.get("event") in {"on_chain_start", "on_tool_start"}:
                 run_starts[run_id] = (timing_key, perf_counter())
             elif event.get("event") in {"on_chain_end", "on_tool_end"} and run_id in run_starts:
                 started_key, started_at = run_starts.pop(run_id)
                 duration_ms = round((perf_counter() - started_at) * 1000, 2)
-                timings[f"{started_key}_ms"] = duration_ms
+                _record_timing(timings, started_key, duration_ms)
 
             event_state = _state_from_graph_event(event)
             if event_state:
@@ -447,6 +446,19 @@ def _graph_event_timing_key(event: dict[str, Any]) -> str:
     if name == "route_after_grade":
         return name
     return _graph_event_node(event)
+
+
+def _record_timing(timings: dict[str, float], key: str, duration_ms: float) -> None:
+    """Store a timing value without overwriting repeated node executions."""
+    base_key = f"{key}_ms"
+    if base_key not in timings:
+        timings[base_key] = duration_ms
+        return
+
+    index = 2
+    while f"{key}_{index}_ms" in timings:
+        index += 1
+    timings[f"{key}_{index}_ms"] = duration_ms
 
 
 def _compact_graph_event(

--- a/apps/dashboard/api_client.py
+++ b/apps/dashboard/api_client.py
@@ -181,7 +181,29 @@ def format_research_log_event(event: dict[str, Any]) -> str:
     if len(text) > 180:
         text = f"{text[:180]}..."
     suffix = f" - {text}" if text else ""
-    return f"{label} {action}{suffix}\n"
+    timing = _format_research_event_timing(event)
+    return f"{label} {action}{suffix}{timing}\n"
+
+
+def _format_research_event_timing(event: dict[str, Any]) -> str:
+    """Return compact latency text for streamed research milestones."""
+    parts: list[str] = []
+    duration_ms = event.get("duration_ms")
+    elapsed_ms = event.get("elapsed_ms")
+    if isinstance(duration_ms, int | float):
+        parts.append(f"소요 {duration_ms / 1000:.2f}s")
+    if isinstance(elapsed_ms, int | float):
+        parts.append(f"누적 {elapsed_ms / 1000:.2f}s")
+    return f" ({', '.join(parts)})" if parts else ""
+
+
+def extract_analyst_draft_delta(event: dict[str, Any]) -> str:
+    """Return analyst token-stream text for the live draft panel."""
+    if event.get("type") != "on_chat_model_stream":
+        return ""
+    if str(event.get("node") or event.get("name") or "") != "analyst":
+        return ""
+    return str(event.get("text") or "")
 
 
 def risk_vector_from_tags(risk_tags: list[str] | None) -> list[float]:

--- a/apps/dashboard/app.py
+++ b/apps/dashboard/app.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 import re
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import numpy as np
@@ -25,6 +25,7 @@ try:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        extract_analyst_draft_delta,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -40,6 +41,7 @@ except ModuleNotFoundError:
         build_optimize_payload,
         calculate_period_return_metrics,
         explain_reasoning_rows,
+        extract_analyst_draft_delta,
         extract_risk_context_from_research_event,
         format_research_log_event,
         get_json,
@@ -121,9 +123,12 @@ def _remember_research_risk_tags(event: dict[str, Any]) -> None:
             st.session_state["research_result"] = result
 
 
-def _stream_research(question: str):
+def _stream_research(question: str, on_draft: Callable[[str], None] | None = None):
     def formatter(event: dict[str, Any]) -> str:
         _remember_research_risk_tags(event)
+        draft_delta = extract_analyst_draft_delta(event)
+        if draft_delta and on_draft:
+            on_draft(draft_delta)
         return _format_research_event(event)
 
     return stream_ndjson(
@@ -920,6 +925,14 @@ def research_page() -> None:
             result_container = st.container()
 
             # 2. 추론 로그 expander — default 닫힘. 사용자가 토글 열면 실시간 진행 노출
+            draft_placeholder = st.empty()
+            draft_text = ""
+
+            def update_draft(delta: str) -> None:
+                nonlocal draft_text
+                draft_text += delta
+                draft_placeholder.markdown(f"**실시간 리포트 초안**\n\n{draft_text}")
+
             with st.expander("추론 로그 보기 (LangGraph reasoning trace)", expanded=False):
                 stream_placeholder = st.empty()
                 stream_placeholder.caption("LangGraph 진행 상황 수신 대기 중…")
@@ -927,7 +940,7 @@ def research_page() -> None:
             # 3. spinner 동안 스트림 chunk를 expander 내부 placeholder에 누적 갱신
             with st.spinner("LangGraph 리서치 진행 중…"):
                 stream_chunks: list[str] = []
-                for chunk in _stream_research(question):
+                for chunk in _stream_research(question, on_draft=update_draft):
                     stream_chunks.append(str(chunk))
                     running_text = "".join(stream_chunks).strip()
                     stream_placeholder.code(
@@ -943,6 +956,8 @@ def research_page() -> None:
             )
 
             # 4. 결과는 위에 예약된 컨테이너에 그림
+            if draft_text:
+                draft_placeholder.empty()
             with result_container:
                 _render_research_result(st.session_state.get("research_result"))
     else:

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -16,6 +16,7 @@ from typing import Annotated, Any, Dict, List, NotRequired, TypedDict
 import chromadb.errors
 import openai
 from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_openai import ChatOpenAI
 
 from apps.api.config import settings
@@ -34,6 +35,13 @@ llm = ChatOpenAI(
     model="gpt-4o-mini",
     temperature=0.3,
     api_key=settings.OPENAI_API_KEY,
+)
+
+analyst_llm = ChatOpenAI(
+    model="gpt-4o-mini",
+    temperature=0.3,
+    api_key=settings.OPENAI_API_KEY,
+    streaming=True,
 )
 
 
@@ -337,7 +345,7 @@ def grade_documents_node(state: AgentState) -> Dict[str, Any]:
     }
 
 
-def analyst_node(state: AgentState) -> Dict[str, Any]:
+def analyst_node(state: AgentState, config: RunnableConfig = None) -> Dict[str, Any]:
     """
     ``context``와 리스크 태그를 근거로 최종 투자 관점 의견을 작성합니다.
 
@@ -400,7 +408,10 @@ def analyst_node(state: AgentState) -> Dict[str, Any]:
     )
 
     try:
-        response = llm.invoke([sys, hum]).content + DISCLAIMER
+        response_parts: list[str] = []
+        for chunk in analyst_llm.stream([sys, hum], config=config):
+            response_parts.append(str(getattr(chunk, "content", "") or ""))
+        response = "".join(response_parts) + DISCLAIMER
     except openai.OpenAIError as e:
         logger.error("analyst: LLM 호출 실패 (%s).", e)
         response = f"[분석 오류] LLM 호출에 실패했습니다: {type(e).__name__}" + DISCLAIMER

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import operator
 import os
+from time import perf_counter
 from typing import Annotated, Any, Dict, List, NotRequired, TypedDict
 
 import chromadb.errors
@@ -18,7 +19,12 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from apps.api.config import settings
-from src.agent.risk_tags import RL_RISK_TAGS, extract_risk_tags, extract_rl_risk_tags, score_risk_vector
+from src.agent.risk_tags import (
+    RL_RISK_TAGS,
+    extract_risk_tags,
+    extract_rl_risk_tags,
+    score_risk_vector,
+)
 from src.agent.vectorstore import collection_document_count, query_documents
 
 logger = logging.getLogger(__name__)
@@ -297,7 +303,10 @@ def grade_documents_node(state: AgentState) -> Dict[str, Any]:
             )
 
     if insufficient and retry < 3:
+        refine_start = perf_counter()
         new_q = _refine_search_query_for_retry(state)
+        refine_ms = (perf_counter() - refine_start) * 1000
+        msgs.append(_think_log("grade_documents", f"retry refine latency={refine_ms:.1f}ms"))
         msgs.append(
             _think_log("grade_documents", f"재검색 결정 ({retry + 1}/3). 신규 쿼리: {new_q[:120]}…")
         )

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -345,7 +345,7 @@ def grade_documents_node(state: AgentState) -> Dict[str, Any]:
     }
 
 
-def analyst_node(state: AgentState, config: RunnableConfig = None) -> Dict[str, Any]:
+def analyst_node(state: AgentState, config: RunnableConfig | None = None) -> Dict[str, Any]:
     """
     ``context``와 리스크 태그를 근거로 최종 투자 관점 의견을 작성합니다.
 

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -410,7 +410,7 @@ def analyst_node(state: AgentState, config: RunnableConfig | None = None) -> Dic
     try:
         response_parts: list[str] = []
         for chunk in analyst_llm.stream([sys, hum], config=config):
-            response_parts.append(str(getattr(chunk, "content", "") or ""))
+            response_parts.append(str(getattr(chunk, "content", "")))
         response = "".join(response_parts) + DISCLAIMER
     except openai.OpenAIError as e:
         logger.error("analyst: LLM 호출 실패 (%s).", e)

--- a/tests/test_agent_grade_documents.py
+++ b/tests/test_agent_grade_documents.py
@@ -1,0 +1,32 @@
+"""Agent document-grading node tests."""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from apps.api.config import settings
+
+settings.OPENAI_API_KEY = settings.OPENAI_API_KEY or "test-key"
+
+from src.agent.nodes import grade_documents_node
+
+
+def test_grade_documents_logs_retry_refine_latency(monkeypatch) -> None:
+    """Retry query refinement should leave a measurable latency log."""
+    monkeypatch.setattr(
+        "src.agent.nodes._refine_search_query_for_retry",
+        lambda state: "보정 쿼리",
+    )
+
+    result = grade_documents_node(
+        {
+            "query": "금리 리스크",
+            "plan": "금리와 주식시장 관련 문서를 찾는다",
+            "documents": [],
+            "distances": [],
+            "retry_count": 0,
+        }
+    )
+
+    assert result["needs_research_retry"] is True
+    assert any("retry refine latency=" in message for message in result["messages"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -769,10 +769,14 @@ def test_research_stream_keeps_nested_route_timing_separate(monkeypatch) -> None
         lines = [json.loads(line) for line in response.iter_lines() if line]
 
     route_end = next(
-        event for event in lines if event.get("name") == "route_after_grade" and event["type"].endswith("_end")
+        event
+        for event in lines
+        if event.get("name") == "route_after_grade" and event["type"].endswith("_end")
     )
     grade_end = next(
-        event for event in lines if event.get("name") == "grade_documents" and event["type"].endswith("_end")
+        event
+        for event in lines
+        if event.get("name") == "grade_documents" and event["type"].endswith("_end")
     )
     complete = lines[-1]
 
@@ -780,6 +784,39 @@ def test_research_stream_keeps_nested_route_timing_separate(monkeypatch) -> None
     assert "duration_ms" in grade_end
     assert "route_after_grade_ms" in complete["timings"]
     assert "grade_documents_ms" in complete["timings"]
+
+
+def test_research_stream_maps_chat_tokens_to_langgraph_node(monkeypatch) -> None:
+    """Chat model stream chunks should use the LangGraph node name for dashboard routing."""
+
+    async def fake_stream_graph_events(question: str):
+        yield {
+            "event": "on_chat_model_stream",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "analyst"},
+            "data": {"chunk": type("Chunk", (), {"content": "실시간 토큰"})()},
+        }
+        yield {
+            "event": "on_chain_end",
+            "name": "analyst",
+            "data": {"output": {"response": "실시간 토큰"}},
+        }
+
+    monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(api_services, "stream_graph_events", fake_stream_graph_events)
+
+    with client.stream(
+        "POST",
+        "/research/stream",
+        json={"question": "금리 급등 리스크는?"},
+    ) as response:
+        lines = [json.loads(line) for line in response.iter_lines() if line]
+
+    assert response.status_code == 200
+    assert lines[1]["type"] == "on_chat_model_stream"
+    assert lines[1]["name"] == "ChatOpenAI"
+    assert lines[1]["node"] == "analyst"
+    assert lines[1]["text"] == "실시간 토큰"
 
 
 def test_research_stream_falls_back_quickly_without_api_key(monkeypatch) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -727,6 +727,61 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
     assert '"risk_signals":[{"tag":"equity_market_risk","severity":0.66}]' in lines[-1]
 
 
+def test_research_stream_keeps_nested_route_timing_separate(monkeypatch) -> None:
+    """Nested router events should not overwrite grade_documents timing."""
+
+    async def fake_stream_graph_events(question: str):
+        yield {
+            "event": "on_chain_start",
+            "name": "grade_documents",
+            "run_id": "grade-run",
+            "data": {"input": {"query": question}},
+        }
+        yield {
+            "event": "on_chain_start",
+            "name": "route_after_grade",
+            "run_id": "route-run",
+            "metadata": {"langgraph_node": "grade_documents"},
+            "data": {"input": {}},
+        }
+        yield {
+            "event": "on_chain_end",
+            "name": "route_after_grade",
+            "run_id": "route-run",
+            "metadata": {"langgraph_node": "grade_documents"},
+            "data": {"output": "analyst"},
+        }
+        yield {
+            "event": "on_chain_end",
+            "name": "grade_documents",
+            "run_id": "grade-run",
+            "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market_risk"]}},
+        }
+
+    monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(api_services, "stream_graph_events", fake_stream_graph_events)
+
+    with client.stream(
+        "POST",
+        "/research/stream",
+        json={"question": "금리 급등 리스크는?"},
+    ) as response:
+        lines = [json.loads(line) for line in response.iter_lines() if line]
+
+    route_end = next(
+        event for event in lines if event.get("name") == "route_after_grade" and event["type"].endswith("_end")
+    )
+    grade_end = next(
+        event for event in lines if event.get("name") == "grade_documents" and event["type"].endswith("_end")
+    )
+    complete = lines[-1]
+
+    assert "duration_ms" in route_end
+    assert "duration_ms" in grade_end
+    assert "route_after_grade_ms" in complete["timings"]
+    assert "grade_documents_ms" in complete["timings"]
+
+
 def test_research_stream_falls_back_quickly_without_api_key(monkeypatch) -> None:
     """POST /research/stream should not block when LangGraph cannot run."""
     monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -679,6 +679,12 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
         yield {"event": "on_parser_start", "name": "ignored", "data": {"input": "skip"}}
         yield {"event": "on_chain_start", "name": "planner", "data": {"input": {"query": question}}}
         yield {
+            "event": "on_chat_model_stream",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "analyst"},
+            "data": {"chunk": type("Chunk", (), {"content": "초안"})()},
+        }
+        yield {
             "event": "on_chain_end",
             "name": "analyst",
             "data": {
@@ -703,15 +709,20 @@ def test_research_stream_returns_ndjson_events(monkeypatch) -> None:
         assert response.headers["x-accel-buffering"] == "no"
         lines = [line for line in response.iter_lines() if line]
 
-    assert len(lines) == 4
+    assert len(lines) == 5
     assert '"type":"start"' in lines[0]
     assert '"type":"on_chain_start"' in lines[1]
     assert '"name":"planner"' in lines[1]
+    assert '"elapsed_ms"' in lines[1]
     assert '"data"' not in lines[1]
     assert len(lines[1]) < 1000
-    assert '"type":"on_chain_end"' in lines[2]
+    assert '"type":"on_chat_model_stream"' in lines[2]
+    assert '"node":"analyst"' in lines[2]
+    assert '"text":"초안"' in lines[2]
+    assert '"type":"on_chain_end"' in lines[3]
     assert '"type":"complete"' in lines[-1]
     assert '"report":"분석 완료"' in lines[-1]
+    assert '"timings"' in lines[-1]
     assert "equity_market_risk" in lines[-1]
     assert '"risk_signals":[{"tag":"equity_market_risk","severity":0.66}]' in lines[-1]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -786,6 +786,76 @@ def test_research_stream_keeps_nested_route_timing_separate(monkeypatch) -> None
     assert "grade_documents_ms" in complete["timings"]
 
 
+def test_research_stream_matches_timing_without_run_id(monkeypatch) -> None:
+    """Events without run_id should still match start/end timing buckets."""
+
+    async def fake_stream_graph_events(question: str):
+        yield {
+            "event": "on_chain_start",
+            "name": "grade_documents",
+            "data": {"input": {"query": question}},
+        }
+        yield {
+            "event": "on_chain_end",
+            "name": "grade_documents",
+            "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market_risk"]}},
+        }
+
+    monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(api_services, "stream_graph_events", fake_stream_graph_events)
+
+    with client.stream(
+        "POST",
+        "/research/stream",
+        json={"question": "금리 급등 리스크는?"},
+    ) as response:
+        lines = [json.loads(line) for line in response.iter_lines() if line]
+
+    grade_end = next(
+        event
+        for event in lines
+        if event.get("name") == "grade_documents" and event["type"].endswith("_end")
+    )
+    complete = lines[-1]
+
+    assert "duration_ms" in grade_end
+    assert "grade_documents_ms" in complete["timings"]
+
+
+def test_research_stream_preserves_repeated_node_timings(monkeypatch) -> None:
+    """Repeated node executions should keep each timing instead of overwriting."""
+
+    async def fake_stream_graph_events(question: str):
+        for run_id in ("grade-run-1", "grade-run-2"):
+            yield {
+                "event": "on_chain_start",
+                "name": "grade_documents",
+                "run_id": run_id,
+                "data": {"input": {"query": question}},
+            }
+            yield {
+                "event": "on_chain_end",
+                "name": "grade_documents",
+                "run_id": run_id,
+                "data": {"output": {"response": "분석 완료", "risk_tags": ["equity_market_risk"]}},
+            }
+
+    monkeypatch.setattr(api_services.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(api_services, "stream_graph_events", fake_stream_graph_events)
+
+    with client.stream(
+        "POST",
+        "/research/stream",
+        json={"question": "금리 급등 리스크는?"},
+    ) as response:
+        lines = [json.loads(line) for line in response.iter_lines() if line]
+
+    complete = lines[-1]
+
+    assert "grade_documents_ms" in complete["timings"]
+    assert "grade_documents_2_ms" in complete["timings"]
+
+
 def test_research_stream_maps_chat_tokens_to_langgraph_node(monkeypatch) -> None:
     """Chat model stream chunks should use the LangGraph node name for dashboard routing."""
 

--- a/tests/test_dashboard_api_client.py
+++ b/tests/test_dashboard_api_client.py
@@ -10,6 +10,7 @@ from apps.dashboard.api_client import (
     build_optimize_payload,
     calculate_period_return_metrics,
     explain_reasoning_rows,
+    extract_analyst_draft_delta,
     extract_risk_signals_from_research_event,
     extract_risk_tags_from_research_event,
     format_research_log_event,
@@ -206,10 +207,29 @@ def test_research_result_from_complete_event() -> None:
 
 def test_research_log_formatter_filters_noisy_chat_chunks() -> None:
     """Dashboard log should hide raw chat token chunks and keep milestones."""
-    assert format_research_log_event({"type": "on_chat_model_stream", "text": "토큰"}) == ""
+    analyst_token = {"type": "on_chat_model_stream", "node": "analyst", "text": "토큰"}
+    assert format_research_log_event(analyst_token) == ""
+    assert extract_analyst_draft_delta(analyst_token) == "토큰"
+    assert (
+        extract_analyst_draft_delta(
+            {"type": "on_chat_model_stream", "node": "planner", "text": "무시"}
+        )
+        == ""
+    )
     assert (
         format_research_log_event({"type": "on_chain_start", "name": "planner"})
         == "질문 분석 시작\n"
+    )
+    assert (
+        format_research_log_event(
+            {
+                "type": "on_chain_end",
+                "name": "analyst",
+                "elapsed_ms": 8800,
+                "duration_ms": 6200,
+            }
+        )
+        == "리포트 작성 완료 (소요 6.20s, 누적 8.80s)\n"
     )
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -10,8 +10,6 @@ class _FakeChunk:
 
 
 class _FakeStreamingLLM:
-    streaming = True
-
     def stream(self, messages, config=None):
         yield _FakeChunk("실시간 ")
         yield _FakeChunk("리포트")

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,6 +1,25 @@
 import pytest
 
+import src.agent.nodes as nodes
 from src.agent.nodes import analyst_node
+
+
+class _FakeChunk:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeStreamingLLM:
+    streaming = True
+
+    def stream(self, messages, config=None):
+        yield _FakeChunk("실시간 ")
+        yield _FakeChunk("리포트")
+
+
+class _FailingInvokeLLM:
+    def invoke(self, messages):
+        raise AssertionError("analyst_node must not use llm.invoke")
 
 
 @pytest.mark.integration
@@ -26,3 +45,24 @@ def test_analyst_node_returns_required_keys():
     assert isinstance(result["rl_risk_tags"], list)
     assert isinstance(result["sources"], list)
     assert len(result["response"]) > 0
+
+
+def test_analyst_node_uses_streaming_llm(monkeypatch):
+    """Analyst should build the final response from a streaming LLM."""
+    monkeypatch.setattr(nodes, "llm", _FailingInvokeLLM())
+    monkeypatch.setattr(nodes, "analyst_llm", _FakeStreamingLLM(), raising=False)
+    state = {
+        "query": "삼성전자 반도체 전망은?",
+        "context": "관련 문서 없음",
+        "documents": [],
+        "risk_tags": [],
+        "messages": [],
+        "retry_count": 0,
+        "needs_research_retry": False,
+        "sources": [],
+        "reasoning_trace": "",
+    }
+
+    result = analyst_node(state)
+
+    assert result["response"].startswith("실시간 리포트")


### PR DESCRIPTION
## 관련 이슈
없음

## 작업 내용
어떤 작업을 했는지 간략히 설명해주세요.

- Research analyst 노드가 `llm.invoke()` 대신 streaming 전용 LLM으로 토큰을 생성하도록 변경
- `/research/stream` chat chunk가 LangGraph node metadata를 보존해 dashboard analyst draft로 라우팅되도록 보강
- analyst token streaming과 nested route timing 회귀 테스트 추가

## 변경된 파일
| 파일 | 변경 내용 |
|------|---------|
| `src/agent/nodes.py` | analyst 전용 streaming LLM 추가 및 `analyst_node()`에서 stream 기반 응답 누적 |
| `apps/api/services.py` | stream compact 이벤트가 `metadata.langgraph_node` 기반 `node` 값을 유지 |
| `tests/test_api.py` | analyst chat token node 라우팅과 timing 회귀 테스트 보강 |
| `tests/test_nodes.py` | analyst 노드가 streaming LLM을 사용하는지 검증 |

## 테스트 결과
```bash
OPENAI_API_KEY=test-key /Users/jimin916/Documents/2026_school/캡디2/rl-rag-roboadvisor/.venv/bin/python -m pytest tests/test_api.py tests/test_nodes.py tests/test_dashboard_api_client.py tests/test_dashboard_app.py
# 48 passed, 21 warnings

OPENAI_API_KEY=test-key /Users/jimin916/Documents/2026_school/캡디2/rl-rag-roboadvisor/.venv/bin/python -m py_compile src/agent/nodes.py apps/api/services.py apps/dashboard/api_client.py apps/dashboard/app.py
# passed
```

## 체크리스트
- [x] 담당 파일 외 다른 팀원 파일 무단 수정 없음
- [x] `.env` 파일 커밋 안 함
- [x] 새 함수/클래스에 docstring 작성
- [x] 테스트 통과 확인 (`pytest`)
- [x] PR 대상 브랜치가 `dev`인지 확인 (셀프 merge 금지)

## 기타 참고 사항
- `feat/research-latency-token-stream` 브랜치에는 기존 latency/draft stream 작업이 포함되어 있으며, 이번 커밋은 실제 analyst token streaming 보장 부분만 추가합니다.
- worktree에 있던 untracked `.superpowers/`는 PR에 포함하지 않았습니다.