### PR TITLE
feat: ChromaDB 일일 자동 갱신 GitHub Actions 스케줄 추가

### DIFF
--- a/.github/workflows/chromadb-refresh.yml
+++ b/.github/workflows/chromadb-refresh.yml
@@ -1,0 +1,21 @@
+name: ChromaDB Daily Refresh
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # 매일 KST 09:00 (UTC 00:00)
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run news collector on server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ${{ secrets.LIGHTSAIL_USER }}
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          script: |
+            cd /opt/roboadvisor
+            docker compose -f docker-compose.prod.yml run --rm collector


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용

AWS Lightsail 자동 배포 파이프라인 구축 및 배포 환경 버그 수정.

- GitHub Actions CI(pytest) / CD(Docker 빌드·배포) 워크플로 추가
- ChromaDB 뉴스 수집 일일 스케줄링 (매일 KST 09:00 자동 실행)


## 변경된 파일

| 파일 | 변경 내용 |
|------|---------|
| `.github/workflows/chromadb-refresh.yml` | 매일 KST 09:00 ChromaDB 뉴스 자동 수집 (신규) |

## 기타 참고 사항

- GitHub Secrets 설정 필요: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `LIGHTSAIL_HOST`, `LIGHTSAIL_USER`(`ec2-user`), `LIGHTSAIL_SSH_KEY`
- schedule 워크플로는 **main 브랜치 머지 후** 활성화됨. 수동 실행은 Actions 탭 → ChromaDB Daily Refresh → Run workflow
